### PR TITLE
Fix SN auth S2S null results blocking registration

### DIFF
--- a/src/components/cyfs-sn/src/s2s_api/sn_auth_db.rs
+++ b/src/components/cyfs-sn/src/s2s_api/sn_auth_db.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 use ::kRPC::{kRPC, RPCErrors, RPCHandler, RPCRequest, RPCResponse, RPCResult};
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::de::{DeserializeOwned, Error as DeError};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -61,11 +62,52 @@ impl SnAuthDbRpcErrorInfo {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SnAuthDbRpcEnvelope<T> {
     pub ok: bool,
     pub result: Option<T>,
     pub error: Option<SnAuthDbRpcErrorInfo>,
+}
+
+#[derive(Deserialize)]
+struct SnAuthDbRpcEnvelopeWire {
+    ok: bool,
+    #[serde(default, deserialize_with = "deserialize_present_json_value")]
+    result: Option<Value>,
+    error: Option<SnAuthDbRpcErrorInfo>,
+}
+
+fn deserialize_present_json_value<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Value::deserialize(deserializer).map(Some)
+}
+
+impl<'de, T> Deserialize<'de> for SnAuthDbRpcEnvelope<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SnAuthDbRpcEnvelopeWire::deserialize(deserializer)?;
+        let result = if wire.ok {
+            wire.result
+                .map(serde_json::from_value)
+                .transpose()
+                .map_err(DeError::custom)?
+        } else {
+            None
+        };
+
+        Ok(Self {
+            ok: wire.ok,
+            result,
+            error: wire.error,
+        })
+    }
 }
 
 impl<T> SnAuthDbRpcEnvelope<T> {
@@ -1419,4 +1461,54 @@ fn rpc_envelope_response<T: Serialize>(
         RPCErrors::ParserResponseError(format!("Failed to serialize SnAuthDB RPC envelope: {}", e))
     })?;
     Ok(RPCResponse::create_by_req(RPCResult::Success(value), req))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_sn_auth_db_url() {
+        assert_eq!(
+            normalize_sn_auth_db_url("http://127.0.0.1:8080"),
+            "http://127.0.0.1:8080/kapi/sn/s2s/auth-db"
+        );
+        assert_eq!(
+            normalize_sn_auth_db_url("http://127.0.0.1:8080/kapi/sn/s2s/auth-db/"),
+            "http://127.0.0.1:8080/kapi/sn/s2s/auth-db"
+        );
+    }
+
+    #[test]
+    fn test_unit_envelope_roundtrip_allows_null_result() {
+        let value = serde_json::to_value(SnAuthDbRpcEnvelope::success(())).unwrap();
+        let envelope: SnAuthDbRpcEnvelope<Value> = serde_json::from_value(value).unwrap();
+
+        assert!(envelope.into_result().is_ok());
+    }
+
+    #[test]
+    fn test_optional_envelope_roundtrip_preserves_null_success() {
+        let value = serde_json::to_value(SnAuthDbRpcEnvelope::success(None::<String>)).unwrap();
+        assert_eq!(value["result"], Value::Null);
+
+        let envelope: SnAuthDbRpcEnvelope<Option<String>> = serde_json::from_value(value).unwrap();
+
+        assert_eq!(envelope.into_result().unwrap(), None);
+    }
+
+    #[test]
+    fn test_error_envelope_null_result_does_not_parse_response_type() {
+        let value = serde_json::to_value(SnAuthDbRpcEnvelope::<String>::failure(sn_err!(
+            SnErrorCode::NotFound,
+            "missing"
+        )))
+        .unwrap();
+        assert_eq!(value["result"], Value::Null);
+
+        let envelope: SnAuthDbRpcEnvelope<String> = serde_json::from_value(value).unwrap();
+        let error = envelope.into_result().unwrap_err();
+
+        assert_eq!(error.code(), SnErrorCode::NotFound);
+    }
 }


### PR DESCRIPTION
## Summary

- preserve a present JSON `null` in successful SN auth S2S envelopes
- deserialize `SnAuthDbRpcEnvelope<Option<T>>` as `Some(None)` instead of treating the result field as missing
- mirror the existing device-info S2S envelope handling and add regression tests

## Problem

The PostgreSQL provider correctly returns a successful miss as `ok=true,result=null`. The default Serde handling for `Option<Option<T>>` conflates a present `null` with an absent field, so `into_result()` reports `SnAuthDB RPC envelope missing result`.

This is a normal response for optional auth queries such as `get_auth` when a user has not registered yet. The registration flow performs this lookup before creating the user. Consequently, a new registration against the PostgreSQL provider aborts before any user or auth rows are written, even though the provider response satisfies the S2S contract.

The same decoding bug also turns normal unknown-domain lookups into remote errors and can cause SN-DNS to return `SERVFAIL`.

## Production-path reproduction

On the `buckyos.io` validation environment:

1. The activation code is valid and available.
2. `auth.register` calls the remote PostgreSQL auth provider.
3. `get_auth` returns `ok=true,result=null` for the new account.
4. The current client raises `SnAuthDB RPC envelope missing result`.
5. Registration stops before side effects; activation remains available and PostgreSQL user/auth row counts remain unchanged.

## Verification

- `cargo test -p cyfs-sn s2s_api::sn_auth_db::tests -- --nocapture`
  - 4 passed, 0 failed on the latest `beta2.2` baseline, also validated together with PR #164
- `cargo test -p cyfs-sn s2s_api:: -- --nocapture`
- `git diff --check`

The repository-wide `cargo fmt --all -- --check` currently reports pre-existing formatting differences on `beta2.2`; this PR does not include unrelated formatting changes.
