### PR TITLE
Fix stale SN DNS cache after BNS writes

### DIFF
--- a/src/components/cyfs-sn/src/name_info_cache.rs
+++ b/src/components/cyfs-sn/src/name_info_cache.rs
@@ -94,6 +94,13 @@ impl NameInfoCache {
         self.write_items().remove(&key).is_some()
     }
 
+    pub(crate) fn remove_matching_names(&self, mut matches: impl FnMut(&str) -> bool) -> usize {
+        let mut items = self.write_items();
+        let previous_len = items.len();
+        items.retain(|key, _| !matches(key.name.as_str()));
+        previous_len - items.len()
+    }
+
     pub fn clear(&self) {
         self.write_items().clear();
     }
@@ -247,5 +254,40 @@ mod tests {
             Duration::from_secs(MIN_NAME_INFO_CACHE_TTL_SECS as u64)
         );
         assert_eq!(cache.effective_ttl(Some(120)), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn remove_matching_names_removes_all_record_types_and_subdomains() {
+        let cache = NameInfoCache::new();
+        let info = NameInfo::from_address(
+            "alice.web3.example.com",
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        );
+        cache.add(
+            "alice.web3.example.com",
+            RecordType::A,
+            info.clone(),
+            Some(600),
+        );
+        cache.add(
+            "home.alice.web3.example.com",
+            RecordType::TXT,
+            info.clone(),
+            Some(600),
+        );
+        cache.add("bob.web3.example.com", RecordType::A, info, Some(600));
+
+        let removed = cache.remove_matching_names(|name| {
+            name == "alice.web3.example.com" || name.ends_with(".alice.web3.example.com")
+        });
+
+        assert_eq!(removed, 2);
+        assert!(cache
+            .query("alice.web3.example.com", RecordType::A)
+            .is_none());
+        assert!(cache
+            .query("home.alice.web3.example.com", RecordType::TXT)
+            .is_none());
+        assert!(cache.query("bob.web3.example.com", RecordType::A).is_some());
     }
 }

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -479,6 +479,19 @@ pub(crate) struct RegisteredDeviceKey {
     pub(crate) device_name: String,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct BnsDnsCacheState {
+    generation: u64,
+    bypass_until: Instant,
+}
+
+#[derive(Clone, Debug)]
+struct BnsDnsCacheQueryState {
+    username: String,
+    generation: u64,
+    bypassed: bool,
+}
+
 #[derive(Clone)]
 pub struct SNServer {
     id: String,
@@ -487,7 +500,7 @@ pub struct SNServer {
     compat_store: SnCompatibilityStoreRef,
     auth: Arc<SnAuthManager>,
     name_info_cache: NameInfoCacheRef,
-    bns_dns_cache_bypass: Arc<RwLock<HashMap<String, Instant>>>,
+    bns_dns_cache_state: Arc<RwLock<HashMap<String, BnsDnsCacheState>>>,
     resolver: SnResolverRef,
     did_resolver: SnDidResolverRef,
     bns_proxy: Arc<SnBnsProxy>,
@@ -671,7 +684,7 @@ impl SNServer {
             compat_store,
             auth,
             name_info_cache: NameInfoCache::new_ref(),
-            bns_dns_cache_bypass: Arc::new(RwLock::new(HashMap::new())),
+            bns_dns_cache_state: Arc::new(RwLock::new(HashMap::new())),
             resolver,
             did_resolver,
             bns_proxy,
@@ -816,23 +829,59 @@ impl SNServer {
         None
     }
 
-    fn should_bypass_bns_dns_cache(&self, name: &str) -> bool {
-        let Some(username) = self.bns_username_for_dns_query(name) else {
-            return false;
-        };
+    fn bns_dns_cache_query_state(&self, name: &str) -> Option<BnsDnsCacheQueryState> {
+        let username = self.bns_username_for_dns_query(name)?;
         let now = Instant::now();
-        let mut bypass = self
-            .bns_dns_cache_bypass
-            .write()
+        let states = self
+            .bns_dns_cache_state
+            .read()
             .unwrap_or_else(|err| err.into_inner());
-        let active = bypass
+        let state = states
             .get(username.as_str())
-            .map(|expires_at| *expires_at > now)
-            .unwrap_or(false);
-        if !active {
-            bypass.remove(username.as_str());
+            .copied()
+            .unwrap_or(BnsDnsCacheState {
+                generation: 0,
+                bypass_until: now,
+            });
+        Some(BnsDnsCacheQueryState {
+            username,
+            generation: state.generation,
+            bypassed: state.bypass_until > now,
+        })
+    }
+
+    fn update_bns_dns_cache_if_current(
+        &self,
+        query_state: Option<&BnsDnsCacheQueryState>,
+        update: impl FnOnce(),
+    ) -> bool {
+        let Some(query_state) = query_state else {
+            update();
+            return true;
+        };
+        if query_state.bypassed {
+            return false;
         }
-        active
+
+        let now = Instant::now();
+        let states = self
+            .bns_dns_cache_state
+            .read()
+            .unwrap_or_else(|err| err.into_inner());
+        let current = states.get(query_state.username.as_str()).copied();
+        let current_generation = current.map(|state| state.generation).unwrap_or(0);
+        let bypassed = current
+            .map(|state| state.bypass_until > now)
+            .unwrap_or(false);
+        if current_generation != query_state.generation || bypassed {
+            return false;
+        }
+
+        // Keep the generation read lock while writing the cache. Invalidation
+        // takes the write lock before incrementing the generation and removing
+        // entries, so an old in-flight resolver can never write after removal.
+        update();
+        true
     }
 
     /// BNS proxy 写投递成功后的本地 DNS 缓存失效（含 tombstone）。
@@ -842,16 +891,16 @@ impl SNServer {
     pub(crate) fn invalidate_bns_name_dns_cache(&self, username: &str) {
         let username = Self::normalize_query_name(username);
         let now = Instant::now();
-        let mut bypass = self
-            .bns_dns_cache_bypass
+        let mut states = self
+            .bns_dns_cache_state
             .write()
             .unwrap_or_else(|err| err.into_inner());
-        bypass.retain(|_, expires_at| *expires_at > now);
-        bypass.insert(
-            username.clone(),
-            now + Duration::from_secs(MIN_NAME_INFO_CACHE_TTL_SECS as u64),
-        );
-        drop(bypass);
+        let state = states.entry(username.clone()).or_insert(BnsDnsCacheState {
+            generation: 0,
+            bypass_until: now,
+        });
+        state.generation = state.generation.wrapping_add(1);
+        state.bypass_until = now + Duration::from_secs(MIN_NAME_INFO_CACHE_TTL_SECS as u64);
 
         self.name_info_cache.remove_matching_names(|name| {
             self.bns_username_for_dns_query(name).as_deref() == Some(username.as_str())
@@ -872,6 +921,7 @@ impl SNServer {
                     .remove(normalized.as_str(), record_type);
             }
         }
+        drop(states);
     }
 
     pub(crate) fn parse_name_record_type(record_type: &str) -> Option<RecordType> {
@@ -960,11 +1010,7 @@ impl SNServer {
     }
 
     fn normalize_query_name(name: &str) -> String {
-        if name.ends_with(".") {
-            name.trim_end_matches('.').to_string()
-        } else {
-            name.to_string()
-        }
+        name.trim().trim_end_matches('.').to_ascii_lowercase()
     }
 
     // 辅助函数：检测字符串是否包含特殊字符
@@ -1613,7 +1659,11 @@ impl NameServer for SNServer {
         );
         let record_type = record_type.unwrap_or_default();
         let req_real_name = Self::normalize_query_name(name);
-        let bypass_bns_cache = self.should_bypass_bns_dns_cache(req_real_name.as_str());
+        let bns_cache_state = self.bns_dns_cache_query_state(req_real_name.as_str());
+        let bypass_bns_cache = bns_cache_state
+            .as_ref()
+            .map(|state| state.bypassed)
+            .unwrap_or(false);
 
         if !bypass_bns_cache {
             match self
@@ -1659,14 +1709,14 @@ impl NameServer for SNServer {
             Ok(resolution) => {
                 let name_info = resolution.into_name_info(name);
                 let cache_ttl_secs = name_info.ttl;
-                if !bypass_bns_cache {
+                self.update_bns_dns_cache_if_current(bns_cache_state.as_ref(), || {
                     self.name_info_cache.add(
                         req_real_name.as_str(),
                         record_type,
                         name_info.clone(),
                         cache_ttl_secs,
                     );
-                }
+                });
                 Ok(name_info)
             }
             Err(e)
@@ -1678,10 +1728,10 @@ impl NameServer for SNServer {
                         | SnResolverErrorKind::DeviceNotFound
                 ) =>
             {
-                if !bypass_bns_cache {
+                self.update_bns_dns_cache_if_current(bns_cache_state.as_ref(), || {
                     self.name_info_cache
                         .add_tombstone(req_real_name.as_str(), record_type, None);
-                }
+                });
                 Err(server_err!(
                     ServerErrorCode::NotFound,
                     "no address found for {}",
@@ -4037,6 +4087,7 @@ mod tests {
                 .await
                 .unwrap();
         assert!(!stale_dns.txt.iter().any(|txt| txt == "pkx=projection"));
+        let stale_cache_state = sn.bns_dns_cache_query_state(dns_name.as_str()).unwrap();
 
         let bns_krpc = kRPC::new(bns_proxy_url.as_str(), Some(access_token));
         let result = bns_krpc
@@ -4067,20 +4118,64 @@ mod tests {
             .query(dns_name.as_str(), RecordType::TXT)
             .is_none());
 
-        // Simulate a DNS query racing ahead of indexer projection and putting
-        // the old answer back after invalidation. The BNS write grace window
-        // must bypass this stale entry instead of extending a one-second
-        // projection delay to the cache's 60-second minimum TTL.
-        sn.name_info_cache
-            .add(dns_name.as_str(), RecordType::TXT, stale_dns, Some(600));
-        let projected_dns =
-            NameServer::query(sn.as_ref(), dns_name.as_str(), Some(RecordType::TXT), None)
-                .await
-                .unwrap();
+        // Simulate a DNS query that started before invalidation and completed
+        // afterward. Its old generation must not be allowed to repopulate the
+        // cache with a long-lived stale value.
+        let inserted = sn.update_bns_dns_cache_if_current(Some(&stale_cache_state), || {
+            sn.name_info_cache.add(
+                dns_name.as_str(),
+                RecordType::TXT,
+                stale_dns.clone(),
+                Some(600),
+            );
+        });
+        assert!(!inserted);
+        let projected_dns = NameServer::query(
+            sn.as_ref(),
+            dns_name.to_ascii_uppercase().as_str(),
+            Some(RecordType::TXT),
+            None,
+        )
+        .await
+        .unwrap();
         assert!(
             projected_dns.txt.iter().any(|txt| txt == "pkx=projection"),
             "{:?}",
             projected_dns.txt
+        );
+
+        // Expire the projection bypass without waiting a minute. The raced
+        // old generation must still be rejected, and a mixed-case query must
+        // continue to resolve and cache the projected value.
+        {
+            let mut states = sn
+                .bns_dns_cache_state
+                .write()
+                .unwrap_or_else(|err| err.into_inner());
+            states.get_mut(PROXY_USER).unwrap().bypass_until = Instant::now();
+        }
+        let inserted_after_bypass =
+            sn.update_bns_dns_cache_if_current(Some(&stale_cache_state), || {
+                sn.name_info_cache
+                    .add(dns_name.as_str(), RecordType::TXT, stale_dns, Some(600));
+            });
+        assert!(!inserted_after_bypass);
+
+        let projected_after_bypass = NameServer::query(
+            sn.as_ref(),
+            dns_name.to_ascii_uppercase().as_str(),
+            Some(RecordType::TXT),
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(
+            projected_after_bypass
+                .txt
+                .iter()
+                .any(|txt| txt == "pkx=projection"),
+            "{:?}",
+            projected_after_bypass.txt
         );
     }
 

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -1,7 +1,9 @@
 use crate::api::{
     handle_auth, handle_bns_proxy, handle_device, handle_dns, handle_domain, handle_user,
 };
-use crate::name_info_cache::{NameInfoCache, NameInfoCacheQueryResult, NameInfoCacheRef};
+use crate::name_info_cache::{
+    NameInfoCache, NameInfoCacheQueryResult, NameInfoCacheRef, MIN_NAME_INFO_CACHE_TTL_SECS,
+};
 use crate::sn_auth_manager::SnAuthManager;
 use crate::sn_bns_proxy::{
     SNBnsProxyConfig, SnBnsControllerBindingStoreRef, SnBnsProxy, SnBnsProxyController,
@@ -53,12 +55,13 @@ use name_client::*;
 use name_lib::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 use std::{
     net::{IpAddr, Ipv4Addr},
     result::Result,
@@ -484,6 +487,7 @@ pub struct SNServer {
     compat_store: SnCompatibilityStoreRef,
     auth: Arc<SnAuthManager>,
     name_info_cache: NameInfoCacheRef,
+    bns_dns_cache_bypass: Arc<RwLock<HashMap<String, Instant>>>,
     resolver: SnResolverRef,
     did_resolver: SnDidResolverRef,
     bns_proxy: Arc<SnBnsProxy>,
@@ -667,6 +671,7 @@ impl SNServer {
             compat_store,
             auth,
             name_info_cache: NameInfoCache::new_ref(),
+            bns_dns_cache_bypass: Arc::new(RwLock::new(HashMap::new())),
             resolver,
             did_resolver,
             bns_proxy,
@@ -793,17 +798,68 @@ impl SNServer {
         self.name_info_cache.remove(name, record_type);
     }
 
+    fn bns_username_for_dns_query(&self, name: &str) -> Option<String> {
+        let normalized = Self::normalize_query_name(name);
+        if !normalized.contains('.') {
+            return canonical_bns_name(normalized.as_str()).ok();
+        }
+
+        let suffix = format!(".web3.{}", self.resolver.config().server_host);
+        let prefix = normalized.strip_suffix(suffix.as_str())?;
+        canonical_bns_name(prefix.rsplit('.').next()?).ok()
+    }
+
+    fn should_bypass_bns_dns_cache(&self, name: &str) -> bool {
+        let Some(username) = self.bns_username_for_dns_query(name) else {
+            return false;
+        };
+        let now = Instant::now();
+        let mut bypass = self
+            .bns_dns_cache_bypass
+            .write()
+            .unwrap_or_else(|err| err.into_inner());
+        let active = bypass
+            .get(username.as_str())
+            .map(|expires_at| *expires_at > now)
+            .unwrap_or(false);
+        if !active {
+            bypass.remove(username.as_str());
+        }
+        active
+    }
+
     /// BNS proxy 写投递成功后的本地 DNS 缓存失效（含 tombstone）。
-    /// 只失效缓存，不伪造 BNS 权威状态；下一次查询会经 resolver 重新读
-    /// bns-rpc 投影（投影未同步期间读到旧值属正常窗口）。
+    /// BNS receipt/submission 会早于 indexer 投影可见；失效后若立即重新缓存
+    /// 旧投影，会把正常的秒级追赶窗口放大为 60 秒。因此对应 BNS name 在
+    /// 一个最小缓存 TTL 内绕过缓存，只读取权威投影。
     pub(crate) fn invalidate_bns_name_dns_cache(&self, username: &str) {
+        let username = Self::normalize_query_name(username);
+        let now = Instant::now();
+        let mut bypass = self
+            .bns_dns_cache_bypass
+            .write()
+            .unwrap_or_else(|err| err.into_inner());
+        bypass.retain(|_, expires_at| *expires_at > now);
+        bypass.insert(
+            username.clone(),
+            now + Duration::from_secs(MIN_NAME_INFO_CACHE_TTL_SECS as u64),
+        );
+        drop(bypass);
+
+        self.name_info_cache.remove_matching_names(|name| {
+            self.bns_username_for_dns_query(name).as_deref() == Some(username.as_str())
+        });
+
         let resolver_config = self.resolver.config();
-        let mut names = vec![username.to_string()];
+        let mut names = vec![username.clone()];
         for host in std::iter::once(resolver_config.server_host.as_str())
             .chain(resolver_config.aliases.iter().map(String::as_str))
         {
+            names.push(format!("{}.web3.{}", username, host));
             names.push(format!("{}.{}", username, host));
         }
+        let resolver_cache = self.resolver.cache();
+        resolver_cache.clear();
         for name in names {
             let normalized = Self::normalize_query_name(name.as_str());
             for record_type in [RecordType::TXT, RecordType::A, RecordType::AAAA] {
@@ -1552,30 +1608,38 @@ impl NameServer for SNServer {
         );
         let record_type = record_type.unwrap_or_default();
         let req_real_name = Self::normalize_query_name(name);
+        let bypass_bns_cache = self.should_bypass_bns_dns_cache(req_real_name.as_str());
 
-        match self
-            .name_info_cache
-            .query(req_real_name.as_str(), record_type)
-        {
-            Some(NameInfoCacheQueryResult::Hit(name_info)) => {
-                info!(
-                    "sn server name cache hit: {} record_type: {:?}",
-                    req_real_name, record_type
-                );
-                return Ok(name_info);
+        if !bypass_bns_cache {
+            match self
+                .name_info_cache
+                .query(req_real_name.as_str(), record_type)
+            {
+                Some(NameInfoCacheQueryResult::Hit(name_info)) => {
+                    info!(
+                        "sn server name cache hit: {} record_type: {:?}",
+                        req_real_name, record_type
+                    );
+                    return Ok(name_info);
+                }
+                Some(NameInfoCacheQueryResult::Tombstone) => {
+                    info!(
+                        "sn server name cache tombstone hit: {} record_type: {:?}",
+                        req_real_name, record_type
+                    );
+                    return Err(server_err!(
+                        ServerErrorCode::NotFound,
+                        "no address found for {}",
+                        name.to_string()
+                    ));
+                }
+                None => {}
             }
-            Some(NameInfoCacheQueryResult::Tombstone) => {
-                info!(
-                    "sn server name cache tombstone hit: {} record_type: {:?}",
-                    req_real_name, record_type
-                );
-                return Err(server_err!(
-                    ServerErrorCode::NotFound,
-                    "no address found for {}",
-                    name.to_string()
-                ));
-            }
-            None => {}
+        } else {
+            debug!(
+                "sn server bypass BNS DNS cache while projection catches up: {} record_type: {:?}",
+                req_real_name, record_type
+            );
         }
 
         info!(
@@ -1590,12 +1654,14 @@ impl NameServer for SNServer {
             Ok(resolution) => {
                 let name_info = resolution.into_name_info(name);
                 let cache_ttl_secs = name_info.ttl;
-                self.name_info_cache.add(
-                    req_real_name.as_str(),
-                    record_type,
-                    name_info.clone(),
-                    cache_ttl_secs,
-                );
+                if !bypass_bns_cache {
+                    self.name_info_cache.add(
+                        req_real_name.as_str(),
+                        record_type,
+                        name_info.clone(),
+                        cache_ttl_secs,
+                    );
+                }
                 Ok(name_info)
             }
             Err(e)
@@ -1607,8 +1673,10 @@ impl NameServer for SNServer {
                         | SnResolverErrorKind::DeviceNotFound
                 ) =>
             {
-                self.name_info_cache
-                    .add_tombstone(req_real_name.as_str(), record_type, None);
+                if !bypass_bns_cache {
+                    self.name_info_cache
+                        .add_tombstone(req_real_name.as_str(), record_type, None);
+                }
                 Err(server_err!(
                     ServerErrorCode::NotFound,
                     "no address found for {}",
@@ -3958,6 +4026,13 @@ mod tests {
         let bound_controller = bns["controller_address"].as_str().unwrap().to_string();
         assert_eq!(bns["asset_owner"].as_str().unwrap(), bound_controller);
 
+        let dns_name = format!("{}.web3.buckyos.ai", PROXY_USER);
+        let stale_dns =
+            NameServer::query(sn.as_ref(), dns_name.as_str(), Some(RecordType::TXT), None)
+                .await
+                .unwrap();
+        assert!(!stale_dns.txt.iter().any(|txt| txt == "pkx=projection"));
+
         let bns_krpc = kRPC::new(bns_proxy_url.as_str(), Some(access_token));
         let result = bns_krpc
             .call(
@@ -3982,6 +4057,26 @@ mod tests {
             .unwrap();
         let inline = String::from_utf8(resolved.document_state.document.inline_document).unwrap();
         assert!(inline.contains("pkx=projection"), "{inline}");
+        assert!(sn
+            .name_info_cache
+            .query(dns_name.as_str(), RecordType::TXT)
+            .is_none());
+
+        // Simulate a DNS query racing ahead of indexer projection and putting
+        // the old answer back after invalidation. The BNS write grace window
+        // must bypass this stale entry instead of extending a one-second
+        // projection delay to the cache's 60-second minimum TTL.
+        sn.name_info_cache
+            .add(dns_name.as_str(), RecordType::TXT, stale_dns, Some(600));
+        let projected_dns =
+            NameServer::query(sn.as_ref(), dns_name.as_str(), Some(RecordType::TXT), None)
+                .await
+                .unwrap();
+        assert!(
+            projected_dns.txt.iter().any(|txt| txt == "pkx=projection"),
+            "{:?}",
+            projected_dns.txt
+        );
     }
 
     #[test]

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -804,9 +804,16 @@ impl SNServer {
             return canonical_bns_name(normalized.as_str()).ok();
         }
 
-        let suffix = format!(".web3.{}", self.resolver.config().server_host);
-        let prefix = normalized.strip_suffix(suffix.as_str())?;
-        canonical_bns_name(prefix.rsplit('.').next()?).ok()
+        let resolver_config = self.resolver.config();
+        for host in std::iter::once(resolver_config.server_host.as_str())
+            .chain(resolver_config.aliases.iter().map(String::as_str))
+        {
+            let suffix = format!(".web3.{}", host);
+            if let Some(prefix) = normalized.strip_suffix(suffix.as_str()) {
+                return canonical_bns_name(prefix.rsplit('.').next()?).ok();
+            }
+        }
+        None
     }
 
     fn should_bypass_bns_dns_cache(&self, name: &str) -> bool {
@@ -858,8 +865,6 @@ impl SNServer {
             names.push(format!("{}.web3.{}", username, host));
             names.push(format!("{}.{}", username, host));
         }
-        let resolver_cache = self.resolver.cache();
-        resolver_cache.clear();
         for name in names {
             let normalized = Self::normalize_query_name(name.as_str());
             for record_type in [RecordType::TXT, RecordType::A, RecordType::AAAA] {


### PR DESCRIPTION
## Root cause

BNS writes invalidate the local DNS cache before the asynchronous BNS read projection necessarily catches up. A query already in flight could finish after invalidation and repopulate a stale answer or tombstone with a much longer TTL. The original fixed 60-second bypass hid that entry temporarily, then allowed it to resurface. Mixed-case DNS names also missed BNS bypass classification while hitting the case-normalized cache.

## Changes

- normalize DNS query names to lowercase before BNS classification and cache access
- maintain a per-BNS-name invalidation generation plus the short projection bypass deadline
- capture the generation before resolving and only write answers/tombstones when it is still current
- hold the generation read lock across the cache write so invalidation cannot race between validation and insertion
- invalidate all matching record types and nested BNS compatibility names
- cover an old in-flight write both during and after bypass expiry, including mixed-case queries

## Impact

Stale entries from a pre-write resolver can no longer return after the bypass expires. Fresh projected data resumes normal caching once the grace window ends.

## Validation

- `cargo test -p cyfs-sn test_sn_bns_proxy_dns_txt_projection_visible_after_submit -- --nocapture`
- `git diff --check`

Related context: #147

