### PR TITLE
fix: preserve BNS nullable and idempotent contracts

### DIFF
--- a/src/components/bns-client/src/rpc.rs
+++ b/src/components/bns-client/src/rpc.rs
@@ -184,10 +184,14 @@ impl<T> BnsRpcEnvelope<T> {
     }
 
     pub fn into_result(self) -> BnsClientResult<T> {
+        self.into_optional_result()?.ok_or_else(|| {
+            BnsClientError::InvalidResponse("BNS RPC envelope missing result".to_string())
+        })
+    }
+
+    fn into_optional_result(self) -> BnsClientResult<Option<T>> {
         if self.ok {
-            self.result.ok_or_else(|| {
-                BnsClientError::InvalidResponse("BNS RPC envelope missing result".to_string())
-            })
+            Ok(self.result)
         } else {
             Err(BnsClientError::Registry(self.error.unwrap_or_else(|| {
                 BnsRpcErrorInfo::new("UNKNOWN_BNS_ERROR", "BNS RPC envelope missing error")
@@ -560,28 +564,60 @@ impl BnsRpcClient {
         Self::KRPC(Arc::new(kRPC::new(endpoint.as_str(), session_token)))
     }
 
+    async fn call_envelope<Req>(&self, method: &str, req: &Req) -> BnsClientResult<Value>
+    where
+        Req: Serialize + Sync,
+    {
+        let Self::KRPC(client) = self else {
+            return Err(BnsClientError::unsupported(
+                "generic call is only available for KRPC clients",
+            ));
+        };
+        let req_json =
+            serde_json::to_value(req).map_err(|e| BnsClientError::Serialization(e.to_string()))?;
+        client
+            .call(method, req_json)
+            .await
+            .map_err(|e| BnsClientError::Transport(e.to_string()))
+    }
+
     async fn call<Req, Resp>(&self, method: &str, req: &Req) -> BnsClientResult<Resp>
     where
         Req: Serialize + Sync,
         Resp: DeserializeOwned,
     {
-        match self {
-            Self::InProcess(_) => Err(BnsClientError::unsupported(
-                "generic call is only available for KRPC clients",
-            )),
-            Self::KRPC(client) => {
-                let req_json = serde_json::to_value(req)
-                    .map_err(|e| BnsClientError::Serialization(e.to_string()))?;
-                let result = client
-                    .call(method, req_json)
-                    .await
-                    .map_err(|e| BnsClientError::Transport(e.to_string()))?;
-                let envelope: BnsRpcEnvelope<Resp> = serde_json::from_value(result)
-                    .map_err(|e| BnsClientError::InvalidResponse(e.to_string()))?;
-                envelope.into_result()
-            }
-        }
+        let envelope: BnsRpcEnvelope<Resp> =
+            serde_json::from_value(self.call_envelope(method, req).await?)
+                .map_err(|e| BnsClientError::InvalidResponse(e.to_string()))?;
+        envelope.into_result()
     }
+
+    async fn call_optional<Req, Resp>(
+        &self,
+        method: &str,
+        req: &Req,
+    ) -> BnsClientResult<Option<Resp>>
+    where
+        Req: Serialize + Sync,
+        Resp: DeserializeOwned,
+    {
+        decode_optional_envelope(self.call_envelope(method, req).await?)
+    }
+}
+
+fn decode_optional_envelope<T: DeserializeOwned>(value: Value) -> BnsClientResult<Option<T>> {
+    let has_result = value
+        .as_object()
+        .is_some_and(|envelope| envelope.contains_key("result"));
+    if !has_result {
+        return Err(BnsClientError::InvalidResponse(
+            "BNS RPC envelope missing result".to_string(),
+        ));
+    }
+
+    let envelope: BnsRpcEnvelope<T> = serde_json::from_value(value)
+        .map_err(|e| BnsClientError::InvalidResponse(e.to_string()))?;
+    envelope.into_optional_result()
 }
 
 /// Compatibility name for callers that still target the legacy indexer path.
@@ -603,7 +639,7 @@ impl BnsIndexerApi for BnsRpcClient {
         match self {
             Self::InProcess(handler) => handler.query_name_state(name).await,
             Self::KRPC(_) => {
-                self.call(METHOD_QUERY_NAME_STATE, &BnsNameReq::new(name))
+                self.call_optional(METHOD_QUERY_NAME_STATE, &BnsNameReq::new(name))
                     .await
             }
         }
@@ -637,7 +673,7 @@ impl BnsIndexerApi for BnsRpcClient {
         match self {
             Self::InProcess(handler) => handler.get_authority_key(name, kid).await,
             Self::KRPC(_) => {
-                self.call(
+                self.call_optional(
                     METHOD_GET_AUTHORITY_KEY,
                     &BnsAuthorityKeyReq {
                         name: name.to_string(),
@@ -671,7 +707,7 @@ impl BnsIndexerApi for BnsRpcClient {
         match self {
             Self::InProcess(handler) => handler.get_document_version(name, doc_type, version).await,
             Self::KRPC(_) => {
-                self.call(
+                self.call_optional(
                     METHOD_GET_DOCUMENT_VERSION,
                     &BnsDocumentVersionReq {
                         name: name.to_string(),
@@ -754,7 +790,10 @@ impl BnsIndexerApi for BnsRpcClient {
     async fn latest_checkpoint(&self) -> BnsClientResult<Option<LogCheckpoint>> {
         match self {
             Self::InProcess(handler) => handler.latest_checkpoint().await,
-            Self::KRPC(_) => self.call(METHOD_LATEST_CHECKPOINT, &json!({})).await,
+            Self::KRPC(_) => {
+                self.call_optional(METHOD_LATEST_CHECKPOINT, &json!({}))
+                    .await
+            }
         }
     }
 }
@@ -943,5 +982,48 @@ mod url_tests {
             normalize_bns_server_url("http://127.0.0.1:18080/custom/rpc/"),
             "http://127.0.0.1:18080/custom/rpc"
         );
+    }
+
+    #[test]
+    fn optional_envelope_accepts_explicit_null_result() {
+        let result = decode_optional_envelope::<Value>(json!({
+            "ok": true,
+            "result": null,
+            "error": null
+        }))
+        .unwrap();
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn optional_envelope_rejects_missing_result_field() {
+        let error = decode_optional_envelope::<Value>(json!({
+            "ok": true,
+            "error": null
+        }))
+        .unwrap_err();
+
+        assert_eq!(error.code(), "INVALID_RESPONSE");
+        assert!(error.to_string().contains("missing result"));
+    }
+
+    #[test]
+    fn optional_envelope_preserves_registry_error() {
+        let error = decode_optional_envelope::<Value>(json!({
+            "ok": false,
+            "result": null,
+            "error": {
+                "code": "NAME_NOT_FOUND",
+                "message": "name was not found",
+                "name": "missing",
+                "doc_type": null,
+                "expected": null,
+                "actual": null
+            }
+        }))
+        .unwrap_err();
+
+        assert_eq!(error.code(), "NAME_NOT_FOUND");
     }
 }

--- a/src/components/cyfs-sn/src/api/auth.rs
+++ b/src/components/cyfs-sn/src/api/auth.rs
@@ -60,10 +60,11 @@ async fn build_auth_success_response(
 }
 
 pub(crate) fn default_owner_config(username: &str) -> Value {
+    // NameState.registered_at is authoritative. Keep this payload stable so a
+    // request_id replay produces the same idempotency hash.
     json!({
         "name": username,
         "created_by": "cyfs-sn",
-        "created_at": now_secs(),
     })
 }
 
@@ -418,5 +419,18 @@ pub(crate) async fn handle_auth(
             ok_response(&req, build_profile_response(username.as_str(), &user))
         }
         _ => Err(RPCErrors::UnknownMethod(req.method)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_owner_config_is_deterministic() {
+        assert_eq!(
+            default_owner_config("alice"),
+            json!({"name": "alice", "created_by": "cyfs-sn"})
+        );
     }
 }

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -4019,6 +4019,9 @@ mod tests {
         assert_eq!(result["reused"].as_bool().unwrap(), false);
         let first_tx_hash = result["tx_hash"].as_str().unwrap().to_string();
 
+        // Cross the old second-based created_at boundary before replaying.
+        tokio::time::sleep(tokio::time::Duration::from_millis(1_100)).await;
+
         // 同 request_id 幂等重放：返回同一笔 TX，reused=true。
         let replay = internal_krpc
             .call(


### PR DESCRIPTION
## Problems

The BNS server correctly returns `ok=true,result=null` for nullable reads such as a missing `name.query_state` result or an empty `checkpoint.latest` result. The current KRPC client deserializes those responses through `BnsRpcEnvelope<Option<T>>`; serde maps the JSON `null` to the envelope's outer `None`, and `into_result()` then reports `INVALID_RESPONSE: BNS RPC envelope missing result`.

This blocks normal BNS misses through `BnsIndexerClient`, even though the raw HTTP contract is valid.

The same end-to-end test also found that an identical `bns.register_name_bootstrap` request could return `IDEMPOTENCY_CONFLICT` when replayed in a later second. An omitted `owner_config` was materialized with a dynamic `created_at`, so the same caller request produced a different payload hash. The BNS `NameState.registered_at` field already carries the authoritative chain registration time.

## Change

- add a dedicated nullable response decoder for `Option<T>` RPC methods
- map an explicit JSON `result:null` to `Ok(None)`
- continue rejecting a genuinely missing `result` field as `INVALID_RESPONSE`
- apply the nullable path to name state, authority key, document version, and latest checkpoint reads
- preserve BNS registry errors such as `NAME_NOT_FOUND`
- keep the default owner document deterministic by removing its redundant dynamic `created_at`
- make the existing bootstrap replay test cross the former second boundary

## Verification

- `cargo test --offline -p bns-client`
  - 35 passed
  - 0 failed
  - 6 Foundry tests ignored by their existing default marker
- live probe against `http://bns.buckyos.io/kapi/bns`
  - missing name: `MISSING_NAME_OK_NONE`
  - empty checkpoint: `CHECKPOINT_OK_NONE`
  - missing owner remains `NAME_NOT_FOUND`
- `cargo test --offline -p cyfs-sn default_owner_config_is_deterministic`
- `cargo test --offline -p cyfs-sn test_sn_bns_proxy_rpc_paths -- --nocapture`
  - replay occurs after 1.1 seconds
  - same nonce and TX hash are returned with `reused=true`
