### PR TITLE
fix: enforce SN internal RPC loopback boundary

### DIFF
--- a/doc/SN/SN-API.md
+++ b/doc/SN/SN-API.md
@@ -365,6 +365,13 @@ SN 代付 gas 的受限 BNS 写代理：用户不需要持有 gas，就能通过
 
 `/` 同时还承载 bns-proxy 的内部/恢复方法 `bns.publish_relay_assignment`、`bns.register_name_bootstrap`（参数与返回见 6.1、6.2）：同一机制，只允许 loopback 来源，不出现在任何公网路径。非 loopback 请求在解析 RPC body 前返回 HTTP 404。
 
+公网 relay 到 SN API 的来源恢复必须满足以下边界：
+
+- TCP/TLS 栈默认不解析 PROXY v1/v2；只有 direct peer 匹配 stack 的 `trusted_upstreams` IP/CIDR 时才解析，公网客户端直连时携带的伪造 PROXY 头不会被解析或剥离。
+- split `web3_relay` 的 `sn.`、`bns.`、`web3.`、apex、`www.` TLS 路由统一发送 PROXY v2。
+- split relay 的明文 HTTP 通过 `X-Forwarded-For` 传递来源，HTTPS 通过 PROXY v2 传递；`web3_sn_api` 两层都只信任 `sn_relay_trusted_upstream`。
+- `sn_relay_trusted_upstream` 默认是同机 `127.0.0.1/32`。跨机部署必须覆盖为 relay 的私网 IP 或尽可能小的私网 CIDR，不能配置公网全网段。
+
 ## 8. 非 RPC 解析接口
 
 SN 仍然提供两个标准解析面，但它们不是 SN RPC：

--- a/doc/SN/SN-API.md
+++ b/doc/SN/SN-API.md
@@ -35,9 +35,9 @@ RPC method 必须使用 `namespace.method` 形式。当前实现不再做 legacy
 | `/kapi/sn/auth` | 公网 | 账号、会话、user/zone profile、user_domain、user DNS record | `auth.*`、`user.*`、`zone.*`、`domain.*` |
 | `/kapi/sn/deviceinfo` | 公网 | 设备在线态上报、在线态查询、OOD 连接信息解析 | `device.*`、`deviceinfo.*` |
 | `/kapi/sn/bns-proxy` | 公网 | SN 代付 gas 的受限 BNS 写代理 | `bns.publish_dns_txt`、`bns.publish_document` |
-| `/` | 内网/管理面 | 运维管理、bns-proxy 内部/恢复方法 | `admin.clear_state_by_active_code`、`bns.publish_relay_assignment`、`bns.register_name_bootstrap` |
+| `/` | 本机管理面（仅 loopback） | 运维管理、bns-proxy 内部/恢复方法 | `admin.clear_state_by_active_code`、`bns.publish_relay_assignment`、`bns.register_name_bootstrap` |
 
-路径是强约束。方法发到非首选路径会返回 unknown method，例如 `auth.check_username` 不能再发到 `/kapi/sn`；`bns.publish_relay_assignment` / `bns.register_name_bootstrap` 不能发到 `/kapi/sn/bns-proxy`，只能发到内网 `/`。
+路径是强约束。方法发到非首选路径会返回 unknown method，例如 `auth.check_username` 不能再发到 `/kapi/sn`；`bns.publish_relay_assignment` / `bns.register_name_bootstrap` 不能发到 `/kapi/sn/bns-proxy`，只能由本机 loopback 客户端发到 `/`。非 loopback 来源访问 `/` 统一返回 HTTP 404。
 
 ## 3. 认证规则
 
@@ -47,7 +47,7 @@ RPC method 必须使用 `namespace.method` 形式。当前实现不再做 legacy
 - `zone.get_info` 接受账号 access token 或 `aud=sn-device` 的短期设备 token；服务端必须从已验证 token 推导 zone，不能接受客户端指定任意 zone。
 - `deviceinfo.resolve_ood_by_did`、`deviceinfo.resolve_ood_by_hostname` 是匿名只读接口。
 - 带用户作用域的接口只允许访问 token 所属用户；即使参数里带 `name`，也必须等于当前登录用户。`bns.publish_dns_txt`、`bns.publish_document` 同样受此约束。
-- `bns.publish_relay_assignment`、`bns.register_name_bootstrap`、`admin.clear_state_by_active_code` 只在内网管理路径 `/` 可用，不做 SN access token 校验，靠网络边界隔离外部访问。
+- `bns.publish_relay_assignment`、`bns.register_name_bootstrap`、`admin.clear_state_by_active_code` 只在本机管理路径 `/` 可用，不做 SN access token 校验；服务端仅允许 loopback 来源，拒绝公网和私网远程来源。
 
 `auth.register` 和 `auth.login` 返回 access/refresh token。access token 放在 kRPC request 的 `token` 字段中。
 
@@ -284,8 +284,8 @@ SN 代付 gas 的受限 BNS 写代理：用户不需要持有 gas，就能通过
 |--------|----------|--------|------|
 | `bns.publish_dns_txt` | `/kapi/sn/bns-proxy`（需 SN access token） | `name`, `mode`, `request_id?`, `ttl?`, `value?`, `records?` | 通过当前用户绑定的 controller 更新 `dns_txt` document。`name` 必须等于 token 所属用户。 |
 | `bns.publish_document` | `/kapi/sn/bns-proxy`（需 SN access token） | `name`, `doc_type`, `document`, `request_id?` | 注册后独立发布 JSON object 或 compact JWT string document；`name` 必须等于 token 所属用户。`relay_assignment` 禁止，`owner` 受身份字段保护。 |
-| `bns.publish_relay_assignment` | 仅内网 `/` | `name`, `relay_assignment`, `request_id?` | SN 内部发布 relay assignment，不经外部 HTTP 路径。 |
-| `bns.register_name_bootstrap` | 仅内网 `/` | `name`, `asset_owner`, `request_id?`, `owner_config?`, `initial_documents?` | 注册阶段以外的恢复/重放入口，不创建本地 SN 账号。 |
+| `bns.publish_relay_assignment` | 仅本机 loopback `/` | `name`, `relay_assignment`, `request_id?` | SN 内部发布 relay assignment，不经外部 HTTP 路径。 |
+| `bns.register_name_bootstrap` | 仅本机 loopback `/` | `name`, `asset_owner`, `request_id?`, `owner_config?`, `initial_documents?` | 注册阶段以外的恢复/重放入口，不创建本地 SN 账号。 |
 
 所有参数结构 `deny_unknown_fields`：客户端不能塞 `controller_address` / `authority` 之类字段来影响服务端的 controller 选择。服务端按 `name`（即 BNS name / 用户名本身）经稳定分配（带权重 rendezvous hashing）取绑定 controller；分配结果持久化在本地 sqlite（`sn_bns_controller_bindings`），一旦写入不会静默改分配——绑定指向的 controller 从配置中消失时，写操作返回 `bns_controller_unavailable`（1027），需要人工迁移。
 
@@ -299,7 +299,7 @@ SN 代付 gas 的受限 BNS 写代理：用户不需要持有 gas，就能通过
 
 `bns.publish_document` 的 `document` 必须是 JSON object 或非空 compact JWT string；其它 JSON scalar 和 array 均拒绝。JSON object 按其 JSON bytes 发布，JWT string 按 UTF-8 原文发布，不会额外包裹 JSON 引号。单个 inline document 上限 4KB。SN 会从当前投影读取版本并自动填写 `expected_version`；客户端不传版本号。成功响应的 `status=submitted` 只表示 TX 已投递，调用方必须等待 bns-indexer 投影并读回相同原文后才能把业务标记为完成。除下面两个保留类型外，`zone`、`boot`、`device_mini_doc` 和自定义 doc_type 均不做产品级 schema 限制：
 
-- `relay_assignment`：返回 `invalid_params`，必须改走内网 `bns.publish_relay_assignment`。
+- `relay_assignment`：返回 `invalid_params`，必须由本机改走 `bns.publish_relay_assignment`。
 - `owner`：只接受 JSON object，不接受 JWT string；允许首次补齐身份字段，也允许更新其它内容；但当前 owner 文档里已经存在的 `public_key`、`owner_key`、`default_key`、`key`、`verificationMethod[0].publicKeyJwk` 不得改值或删除，否则返回 `invalid_params`，且不会构造/投递 TX。
 
 ### 6.2 返回结构
@@ -355,15 +355,15 @@ SN 代付 gas 的受限 BNS 写代理：用户不需要持有 gas，就能通过
 - 新注册用户的 controller policy 使用空 doc_type 通配规则，以承载注册后新增的内容型 document；SN 应用层继续硬隔离 relay 专用入口，并通过受保护的 owner 路径锁定已经存在的身份字段。存量用户的链上 policy 不会自动升级。
 - `bns_proxy.require_user_asset_owner`：配置了 `bns_proxy.controllers`（生产多 controller 模式）缺省 `true`；仅旧版单 controller 配置缺省 `false`（devtest，`asset_owner` 缺省回落为该用户绑定 controller 的地址）。
 
-## 7. 内网管理 RPC
+## 7. 本机管理 RPC
 
-`admin.clear_state_by_active_code` 只允许发到内网管理根路径 `/`，不允许出现在 `/kapi/sn/auth`、`/kapi/sn/deviceinfo`、`/kapi/sn/bns-proxy` 或 `/kapi/sn`。
+`admin.clear_state_by_active_code` 只允许由 loopback 客户端发到本机管理根路径 `/`，不允许出现在 `/kapi/sn/auth`、`/kapi/sn/deviceinfo`、`/kapi/sn/bns-proxy` 或 `/kapi/sn`。
 
 | Method | Params | Result | 说明 |
 |--------|--------|--------|------|
 | `admin.clear_state_by_active_code` | `{}` | `code`, `deleted_users`, `deleted_devices`, `deleted_domain_records`, `deleted_did_documents`, `activation_code_reset` | 清理内置激活码关联的测试/运维状态。请求参数中不允许带 `active_code`。 |
 
-`/` 同时还承载 bns-proxy 的内部/恢复方法 `bns.publish_relay_assignment`、`bns.register_name_bootstrap`（参数与返回见 6.1、6.2）：同一机制，只允许出现在 `/`，不出现在任何公网路径。
+`/` 同时还承载 bns-proxy 的内部/恢复方法 `bns.publish_relay_assignment`、`bns.register_name_bootstrap`（参数与返回见 6.1、6.2）：同一机制，只允许 loopback 来源，不出现在任何公网路径。非 loopback 请求在解析 RPC body 前返回 HTTP 404。
 
 ## 8. 非 RPC 解析接口
 

--- a/doc/SN/[DONE] sn-bns-proxy-todo.md
+++ b/doc/SN/[DONE] sn-bns-proxy-todo.md
@@ -32,8 +32,9 @@
   纯旧配置（仅 `bns_evm.controller_private_key*`）→ false，保持 devtest 兼容，此时
   asset_owner 缺省回落为**该用户绑定 controller** 的地址。
 - internal/admin 方法（`bns.publish_relay_assignment` / `bns.register_name_bootstrap`）
-  与 `admin.clear_state_by_active_code` 同机制：钉在 InternalRoot(`/`)，外部
-  `/kapi/sn/bns-proxy` HTTP 路径不可达。
+  与 `admin.clear_state_by_active_code` 同机制：钉在 InternalRoot(`/`)，仅允许
+  loopback 来源；非 loopback 请求返回 HTTP 404，外部 `/kapi/sn/bns-proxy`
+  HTTP 路径不可达。
 - 绑定表在 SN 本地 sqlite（与 `sn_bns_write_requests` 账本同文件）；db_type=postgres
   时同样落本地（与写请求账本现状一致）。多实例 SN 共享 postgres 部署时，绑定表
   需要共享盘或后续挪到 provider 侧——单独议题，不在本次范围。

--- a/src/components/cyfs-gateway-lib/src/stack/proxy_protocol.rs
+++ b/src/components/cyfs-gateway-lib/src/stack/proxy_protocol.rs
@@ -1,4 +1,4 @@
-use crate::{StackErrorCode, StackResult, into_stack_err, stack_err};
+use crate::{StackErrorCode, StackResult, TrustedUpstreamMatcher, into_stack_err, stack_err};
 use buckyos_kit::AsyncStream;
 use cyfs_process_chain::PrefixedStream;
 use std::net::{IpAddr, SocketAddr};
@@ -18,6 +18,35 @@ pub(crate) enum ProxyProbeResult {
         consumed: usize,
         source_addr: Option<SocketAddr>,
     },
+}
+
+pub fn parse_proxy_protocol_trusted_upstreams(
+    patterns: &[String],
+) -> StackResult<Vec<TrustedUpstreamMatcher>> {
+    patterns
+        .iter()
+        .map(|pattern| {
+            TrustedUpstreamMatcher::parse(pattern)
+                .map_err(|err| stack_err!(StackErrorCode::InvalidConfig, "{}", err))
+        })
+        .collect()
+}
+
+/// Parse PROXY headers only when the direct peer matches an explicitly trusted
+/// IP/CIDR. An empty list is fail-closed and treats the preamble as application
+/// data, so public clients cannot replace their connection identity.
+pub async fn probe_proxy_protocol_stream_from_trusted_upstream(
+    stream: Box<dyn AsyncStream>,
+    direct_peer: SocketAddr,
+    trusted_upstreams: &[TrustedUpstreamMatcher],
+) -> StackResult<(Box<dyn AsyncStream>, Option<SocketAddr>)> {
+    if !trusted_upstreams
+        .iter()
+        .any(|matcher| matcher.matches(&direct_peer.ip()))
+    {
+        return Ok((stream, None));
+    }
+    probe_proxy_protocol_stream(stream).await
 }
 
 /// Probe the inbound stream for a PROXY protocol (v1/v2) header and strip it.
@@ -343,5 +372,66 @@ mod tests {
     fn not_proxy_passthrough() {
         let data = b"GET / HTTP/1.1\r\n\r\n";
         matches!(parse_proxy_protocol(data), ProxyProbeResult::NotProxy);
+    }
+
+    #[tokio::test]
+    async fn untrusted_peer_cannot_spoof_loopback_with_proxy_header() {
+        let claimed_source: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+        let destination: SocketAddr = "192.0.2.10:443".parse().unwrap();
+        let header = encode_proxy_v2_header(claimed_source, destination);
+        let (mut client, server) = tokio::io::duplex(1024);
+        client.write_all(&header).await.unwrap();
+
+        let direct_peer: SocketAddr = "198.51.100.20:40000".parse().unwrap();
+        let (mut stream, restored_source) = probe_proxy_protocol_stream_from_trusted_upstream(
+            Box::new(server),
+            direct_peer,
+            &[TrustedUpstreamMatcher::parse("127.0.0.1/32").unwrap()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(restored_source, None);
+
+        let mut received = vec![0u8; header.len()];
+        stream.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, header);
+    }
+
+    #[tokio::test]
+    async fn loopback_relay_can_restore_proxy_source() {
+        let claimed_source: SocketAddr = "198.51.100.20:40000".parse().unwrap();
+        let destination: SocketAddr = "127.0.0.1:3443".parse().unwrap();
+        let header = encode_proxy_v2_header(claimed_source, destination);
+        let (mut client, server) = tokio::io::duplex(1024);
+        client.write_all(&header).await.unwrap();
+
+        let direct_peer: SocketAddr = "127.0.0.1:50000".parse().unwrap();
+        let (_, restored_source) = probe_proxy_protocol_stream_from_trusted_upstream(
+            Box::new(server),
+            direct_peer,
+            &[TrustedUpstreamMatcher::parse("127.0.0.1/32").unwrap()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(restored_source, Some(claimed_source));
+    }
+
+    #[tokio::test]
+    async fn configured_private_relay_can_restore_proxy_source() {
+        let claimed_source: SocketAddr = "198.51.100.20:40000".parse().unwrap();
+        let destination: SocketAddr = "10.20.0.15:3444".parse().unwrap();
+        let header = encode_proxy_v2_header(claimed_source, destination);
+        let (mut client, server) = tokio::io::duplex(1024);
+        client.write_all(&header).await.unwrap();
+
+        let direct_peer: SocketAddr = "10.20.0.8:50000".parse().unwrap();
+        let (_, restored_source) = probe_proxy_protocol_stream_from_trusted_upstream(
+            Box::new(server),
+            direct_peer,
+            &[TrustedUpstreamMatcher::parse("10.20.0.0/24").unwrap()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(restored_source, Some(claimed_source));
     }
 }

--- a/src/components/cyfs-gateway-lib/src/stack/tcp_stack.rs
+++ b/src/components/cyfs-gateway-lib/src/stack/tcp_stack.rs
@@ -1,6 +1,6 @@
 use super::{
-    Stack, get_limit_info, get_source_addr_from_req_env, probe_proxy_protocol_stream,
-    stream_forward, stream_forward_group,
+    Stack, get_limit_info, get_source_addr_from_req_env, parse_proxy_protocol_trusted_upstreams,
+    probe_proxy_protocol_stream_from_trusted_upstream, stream_forward, stream_forward_group,
 };
 use crate::forward::ForwardPlan;
 
@@ -17,8 +17,9 @@ use crate::{
     HandleConnectionController, IoDumpStackConfig, JsExternalsManagerRef, LimiterManagerRef,
     MutComposedSpeedStat, MutComposedSpeedStatRef, ProcessChainConfig, ProcessChainConfigs, Server,
     ServerManagerRef, StackConfig, StackContext, StackErrorCode, StackFactory, StackProtocol,
-    StackRef, StatManagerRef, StreamInfo, TunnelManager, create_io_dump_stack_config,
-    get_external_commands, get_stat_info, hyper_serve_http, into_stack_err, stack_err,
+    StackRef, StatManagerRef, StreamInfo, TrustedUpstreamMatcher, TunnelManager,
+    create_io_dump_stack_config, get_external_commands, get_stat_info, hyper_serve_http,
+    into_stack_err, stack_err,
 };
 use cyfs_process_chain::{CollectionValue, CommandControl, ProcessChainLibExecutor, StreamRequest};
 use serde::{Deserialize, Serialize};
@@ -76,6 +77,7 @@ struct TcpConnectionHandler {
     executor: ProcessChainLibExecutor,
     connection_manager: Option<ConnectionManagerRef>,
     io_dump: Option<IoDumpStackConfig>,
+    trusted_upstreams: Vec<TrustedUpstreamMatcher>,
 }
 
 impl TcpConnectionHandler {
@@ -84,6 +86,7 @@ impl TcpConnectionHandler {
         env: Arc<TcpStackContext>,
         connection_manager: Option<ConnectionManagerRef>,
         io_dump: Option<IoDumpStackConfig>,
+        trusted_upstreams: Vec<String>,
     ) -> StackResult<Self> {
         let (executor, _) = create_process_chain_executor(
             &hook_point,
@@ -99,6 +102,7 @@ impl TcpConnectionHandler {
             executor,
             connection_manager,
             io_dump,
+            trusted_upstreams: parse_proxy_protocol_trusted_upstreams(&trusted_upstreams)?,
         })
     }
 
@@ -121,6 +125,7 @@ impl TcpConnectionHandler {
             executor,
             connection_manager: self.connection_manager.clone(),
             io_dump,
+            trusted_upstreams: self.trusted_upstreams.clone(),
         })
     }
 
@@ -147,7 +152,12 @@ impl TcpConnectionHandler {
             } else {
                 Box::new(stream)
             };
-        let (req_stream, proxy_source_addr) = probe_proxy_protocol_stream(req_stream).await?;
+        let (req_stream, proxy_source_addr) = probe_proxy_protocol_stream_from_trusted_upstream(
+            req_stream,
+            remote_addr,
+            &self.trusted_upstreams,
+        )
+        .await?;
         let request_source_addr = proxy_source_addr.unwrap_or(remote_addr);
         let device_lookup_ip = request_source_addr.ip();
         let mut request = StreamRequest::new(req_stream, dest_addr);
@@ -410,6 +420,7 @@ impl TcpStack {
             transparent: false,
             io_dump: None,
             reuse_address: false,
+            trusted_upstreams: Vec::new(),
         }
     }
 
@@ -444,6 +455,7 @@ impl TcpStack {
             env,
             config.connection_manager.clone(),
             config.io_dump,
+            config.trusted_upstreams,
         )
         .await?;
 
@@ -686,6 +698,7 @@ impl Stack for TcpStack {
             env,
             self.connection_manager.clone(),
             io_dump,
+            config.trusted_upstreams.clone(),
         )
         .await?;
 
@@ -713,6 +726,7 @@ pub struct TcpStackBuilder {
     transparent: bool,
     io_dump: Option<IoDumpStackConfig>,
     reuse_address: bool,
+    trusted_upstreams: Vec<String>,
 }
 
 impl TcpStackBuilder {
@@ -743,6 +757,11 @@ impl TcpStackBuilder {
 
     pub fn reuse_address(mut self, reuse_address: bool) -> Self {
         self.reuse_address = reuse_address;
+        self
+    }
+
+    pub fn trusted_upstreams(mut self, trusted_upstreams: Vec<String>) -> Self {
+        self.trusted_upstreams = trusted_upstreams;
         self
     }
 
@@ -780,6 +799,8 @@ pub struct TcpStackConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_dump_max_download_bytes_per_conn: Option<String>,
     pub reuse_address: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trusted_upstreams: Vec<String>,
     pub hook_point: Vec<ProcessChainConfig>,
 }
 
@@ -847,6 +868,7 @@ impl StackFactory for TcpStackFactory {
             .connection_manager(self.connection_manager.clone())
             .transparent(config.transparent.unwrap_or(false))
             .reuse_address(config.reuse_address.unwrap_or(false))
+            .trusted_upstreams(config.trusted_upstreams.clone())
             .hook_point(config.hook_point.clone())
             .stack_context(handler_env)
             .io_dump(io_dump)
@@ -1125,7 +1147,13 @@ mod tests {
         assert_eq!(connection_manager.get_all_connection_info().len(), 0);
     }
 
-    async fn run_tcp_source_vars_case(bind: &str, chain_condition: &str, client_payload: &[u8]) {
+    async fn run_tcp_source_vars_case(
+        bind: &str,
+        chain_condition: &str,
+        client_payload: &[u8],
+        trusted_upstreams: Vec<String>,
+        expected_payload: &[u8; 5],
+    ) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let echo_port = listener.local_addr().unwrap().port();
 
@@ -1153,6 +1181,7 @@ mod tests {
             .id("test")
             .bind(bind)
             .hook_point(chains)
+            .trusted_upstreams(trusted_upstreams)
             .stack_context(handler_env)
             .build()
             .await
@@ -1169,7 +1198,7 @@ mod tests {
         let (mut conn, _) = accepted.unwrap();
         let mut buf = [0u8; 5];
         conn.read_exact(&mut buf).await.unwrap();
-        assert_eq!(&buf, b"hello");
+        assert_eq!(&buf, expected_payload);
     }
 
     #[tokio::test]
@@ -1179,6 +1208,8 @@ mod tests {
         run_tcp_source_vars_case(
             "127.0.0.1:8180",
             r#"eq ${REQ.real_source_ip} "" && eq ${REQ.conn_source_ip} "127.0.0.1" && eq ${REQ.source_ip} "127.0.0.1""#,
+            b"hello",
+            Vec::new(),
             b"hello",
         )
         .await;
@@ -1196,6 +1227,23 @@ mod tests {
             "127.0.0.1:8181",
             r#"eq ${REQ.real_source_ip} "203.0.113.9" && eq ${REQ.real_source_port} "5678" && eq ${REQ.conn_source_ip} "127.0.0.1" && eq ${REQ.source_ip} "203.0.113.9" && eq ${REQ.source_port} "5678""#,
             &payload,
+            vec!["127.0.0.1/32".to_string()],
+            b"hello",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_tcp_stack_untrusted_proxy_header_is_not_parsed() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(b"PROXY TCP4 127.0.0.1 127.0.0.1 5678 80\r\n");
+        payload.extend_from_slice(b"hello");
+        run_tcp_source_vars_case(
+            "127.0.0.1:8182",
+            r#"eq ${REQ.real_source_ip} "" && eq ${REQ.conn_source_ip} "127.0.0.1" && eq ${REQ.source_ip} "127.0.0.1""#,
+            &payload,
+            Vec::new(),
+            b"PROXY",
         )
         .await;
     }
@@ -1887,6 +1935,7 @@ mod tests {
             io_dump_max_upload_bytes_per_conn: None,
             io_dump_max_download_bytes_per_conn: None,
             reuse_address: None,
+            trusted_upstreams: Vec::new(),
             hook_point: vec![],
         };
 

--- a/src/components/cyfs-gateway-lib/src/stack/tls_stack.rs
+++ b/src/components/cyfs-gateway-lib/src/stack/tls_stack.rs
@@ -8,7 +8,8 @@ use crate::stack::tls_cert_resolver::{
     IdentityCertResolver, ResolvesServerCertUsingSni, TlsIdentityCertConfig, TlsIdentityHost,
 };
 use crate::stack::{
-    TlsCertResolver, get_limit_info, get_source_addr_from_req_env, probe_proxy_protocol_stream,
+    TlsCertResolver, get_limit_info, get_source_addr_from_req_env,
+    parse_proxy_protocol_trusted_upstreams, probe_proxy_protocol_stream_from_trusted_upstream,
     stream_forward, stream_forward_group,
 };
 use crate::{
@@ -16,8 +17,8 @@ use crate::{
     HandleConnectionController, IoDumpStackConfig, JsExternalsManagerRef, LimiterManagerRef,
     MutComposedSpeedStat, MutComposedSpeedStatRef, ProcessChainConfigs, Server, ServerManagerRef,
     Stack, StackConfig, StackContext, StackErrorCode, StackProtocol, StackResult, StatManagerRef,
-    StreamInfo, TunnelManager, create_io_dump_stack_config, get_external_commands, get_stat_info,
-    hyper_serve_http, into_stack_err, stack_err,
+    StreamInfo, TrustedUpstreamMatcher, TunnelManager, create_io_dump_stack_config,
+    get_external_commands, get_stat_info, hyper_serve_http, into_stack_err, stack_err,
 };
 use cyfs_process_chain::{CollectionValue, CommandControl, ProcessChainLibExecutor, StreamRequest};
 use name_client::IdentityRoots;
@@ -125,6 +126,7 @@ struct TlsConnectionHandler {
     alpn_protocols: Vec<Vec<u8>>,
     server_config: Arc<ServerConfig>,
     io_dump: Option<IoDumpStackConfig>,
+    trusted_upstreams: Vec<TrustedUpstreamMatcher>,
 }
 
 impl TlsConnectionHandler {
@@ -136,6 +138,7 @@ impl TlsConnectionHandler {
         env: Arc<TlsStackContext>,
         connection_manager: Option<ConnectionManagerRef>,
         io_dump: Option<IoDumpStackConfig>,
+        trusted_upstreams: Vec<String>,
     ) -> StackResult<Self> {
         let (executor, _) = create_process_chain_executor(
             &hook_point,
@@ -156,6 +159,7 @@ impl TlsConnectionHandler {
             alpn_protocols,
             server_config,
             io_dump,
+            trusted_upstreams: parse_proxy_protocol_trusted_upstreams(&trusted_upstreams)?,
         })
     }
 
@@ -177,6 +181,7 @@ impl TlsConnectionHandler {
             alpn_protocols: self.alpn_protocols.clone(),
             server_config: self.server_config.clone(),
             io_dump: self.io_dump.clone(),
+            trusted_upstreams: self.trusted_upstreams.clone(),
         })
     }
 
@@ -263,7 +268,12 @@ impl TlsConnectionHandler {
             StackErrorCode::ServerError,
             "read remote addr failed"
         ))?;
-        let (stream, proxy_source_addr) = probe_proxy_protocol_stream(Box::new(stream)).await?;
+        let (stream, proxy_source_addr) = probe_proxy_protocol_stream_from_trusted_upstream(
+            Box::new(stream),
+            remote_addr,
+            &self.trusted_upstreams,
+        )
+        .await?;
         let request_source_addr = proxy_source_addr.unwrap_or(remote_addr);
 
         let tls_acceptor = TlsAcceptor::from(self.server_config.clone());
@@ -570,6 +580,7 @@ impl TlsStack {
             env,
             config.connection_manager.clone(),
             config.io_dump,
+            config.trusted_upstreams,
         )
         .await?;
 
@@ -778,6 +789,7 @@ impl Stack for TlsStack {
             )
             .await
             .map_err(|e| stack_err!(StackErrorCode::InvalidConfig, "{e}"))?,
+            config.trusted_upstreams.clone(),
         )
         .await?;
 
@@ -888,6 +900,8 @@ pub struct TlsStackConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_dump_max_download_bytes_per_conn: Option<String>,
     pub reuse_address: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trusted_upstreams: Vec<String>,
 }
 
 async fn build_tls_domain_configs(config: &TlsStackConfig) -> StackResult<Vec<TlsDomainConfig>> {
@@ -1070,6 +1084,7 @@ impl crate::StackFactory for TlsStackFactory {
                     .collect(),
             )
             .reuse_address(config.reuse_address.unwrap_or(false))
+            .trusted_upstreams(config.trusted_upstreams.clone())
             .stack_context(stack_context)
             .io_dump(io_dump)
             .build()
@@ -1090,6 +1105,7 @@ pub struct TlsStackBuilder {
     stack_context: Option<Arc<TlsStackContext>>,
     io_dump: Option<IoDumpStackConfig>,
     reuse_address: bool,
+    trusted_upstreams: Vec<String>,
 }
 
 impl TlsStackBuilder {
@@ -1106,6 +1122,7 @@ impl TlsStackBuilder {
             stack_context: None,
             io_dump: None,
             reuse_address: false,
+            trusted_upstreams: Vec::new(),
         }
     }
 
@@ -1165,6 +1182,11 @@ impl TlsStackBuilder {
 
     pub fn reuse_address(mut self, reuse_address: bool) -> Self {
         self.reuse_address = reuse_address;
+        self
+    }
+
+    pub fn trusted_upstreams(mut self, trusted_upstreams: Vec<String>) -> Self {
+        self.trusted_upstreams = trusted_upstreams;
         self
     }
 
@@ -1908,6 +1930,7 @@ mod tests {
             stack_context,
             None,
             None,
+            Vec::new(),
         )
         .await
         .unwrap();
@@ -2692,6 +2715,7 @@ mod tests {
             io_dump_max_upload_bytes_per_conn: None,
             io_dump_max_download_bytes_per_conn: None,
             reuse_address: None,
+            trusted_upstreams: Vec::new(),
         };
         let stack_context: Arc<dyn StackContext> = Arc::new(TlsStackContext::new(
             server_manager,

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -442,6 +442,10 @@ fn get_request_client_ip(
         .or_else(|| info.src_addr.as_deref().and_then(parse_ip_or_socket_addr))
 }
 
+fn is_internal_rpc_client_allowed(client_ip: IpAddr) -> bool {
+    client_ip.is_loopback()
+}
+
 impl SnRpcPath {
     fn parse(path: &str) -> Option<Self> {
         match path {
@@ -1826,6 +1830,21 @@ impl HttpServer for SNServer {
             }
         };
 
+        if rpc_path == SnRpcPath::InternalRoot && !is_internal_rpc_client_allowed(client_ip) {
+            warn!(
+                "Rejected external request to SN internal RPC root from {}",
+                client_ip
+            );
+            return Ok(Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(BoxBody::new(
+                    Full::new(Bytes::from_static(b"Not Found"))
+                        .map_err(|never| match never {})
+                        .boxed(),
+                ))
+                .unwrap());
+        }
+
         let body_bytes = match request.collect().await {
             Ok(data) => data.to_bytes(),
             Err(e) => {
@@ -2726,6 +2745,18 @@ mod tests {
     const ANVIL_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     const ANVIL_ADDRESS: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+    #[test]
+    fn internal_rpc_root_only_allows_loopback_clients() {
+        assert!(is_internal_rpc_client_allowed("127.0.0.1".parse().unwrap()));
+        assert!(is_internal_rpc_client_allowed("::1".parse().unwrap()));
+        assert!(!is_internal_rpc_client_allowed(
+            "10.0.0.10".parse().unwrap()
+        ));
+        assert!(!is_internal_rpc_client_allowed(
+            "198.51.100.10".parse().unwrap()
+        ));
+    }
 
     fn test_bns_system_info() -> BnsSystemInfo {
         BnsSystemInfo {

--- a/src/web3-gateway/params.json
+++ b/src/web3-gateway/params.json
@@ -18,6 +18,7 @@
         "sni_bind": "0.0.0.0:443",
         "tls_port": "3443",
         "sn_api_addr": "127.0.0.1",
+        "sn_relay_trusted_upstream": "127.0.0.1/32",
         "api_http_bind": "0.0.0.0:3080",
         "api_http_port": "3080",
         "api_tls_bind": "0.0.0.0:3444",

--- a/src/web3-gateway/web3_gateway.yaml
+++ b/src/web3-gateway/web3_gateway.yaml
@@ -137,6 +137,9 @@ stacks:
   main_tls:
     bind: "{{tls_bind}}"
     protocol: tls
+    trusted_upstreams:
+      - "127.0.0.1/32"
+      - "::1/128"
     hosts:
       - host: "sn.{{sn_host}}"
         cert_path: "{{sn_cer}}"

--- a/src/web3-gateway/web3_gateway.yaml
+++ b/src/web3-gateway/web3_gateway.yaml
@@ -176,15 +176,15 @@ stacks:
               call https-sni-probe || reject; 
               map-create "REQ.ext";
               map-add "REQ.ext" "proxy_source_addr" "${REQ.source_addr}";
-              eq ${REQ.dest_host} "bns.{{sn_host}}" && return "forward tcp:///:{{tls_port}}";
-              eq ${REQ.dest_host} "sn.{{sn_host}}" && return "forward tcp:///:{{tls_port}}";
-              eq ${REQ.dest_host} "www.{{sn_host}}" && return "forward tcp:///:{{tls_port}}";
-              eq ${REQ.dest_host} "{{sn_host}}" && return "forward tcp:///:{{tls_port}}";
-              eq ${REQ.dest_host} "web3.{{sn_host}}" && return "forward tcp:///:{{tls_port}}";
+              eq ${REQ.dest_host} "bns.{{sn_host}}" && return "forward tcp:///:{{tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "sn.{{sn_host}}" && return "forward tcp:///:{{tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "www.{{sn_host}}" && return "forward tcp:///:{{tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "{{sn_host}}" && return "forward tcp:///:{{tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "web3.{{sn_host}}" && return "forward tcp:///:{{tls_port}}?proxy_protocol=v2";
               map-create "QUESTION" && map-add "QUESTION" "dest_host" "${REQ.dest_host}" && map-add "QUESTION" "method" "deviceinfo.resolve_ood_by_hostname";
               call qa "web3_sn" "QUESTION";
               eq ${ANSWER.self_cert} "true" && return "forward rtcp://${ANSWER.did_hostname}/:443";
               match ${REQ.dest_host} "*.*.web3.{{sn_host}}" && eq ${ANSWER.self_cert} "false" && error --from chain "self_cert=false for ${REQ.dest_host}; enable self_cert to use nested web3 host over HTTPS";
-              match ${REQ.dest_host} "*.web3.{{sn_host}}" && return "forward tcp:///:{{tls_port}}";
+              match ${REQ.dest_host} "*.web3.{{sn_host}}" && return "forward tcp:///:{{tls_port}}?proxy_protocol=v2";
               reject;
   

--- a/src/web3-gateway/web3_relay.yaml
+++ b/src/web3-gateway/web3_relay.yaml
@@ -156,5 +156,5 @@ stacks:
               call qa "web3_sn" "QUESTION";
               eq ${ANSWER.self_cert} "true" && return "forward rtcp://${ANSWER.did_hostname}/:443";
               match ${REQ.dest_host} "*.*.web3.{{sn_host}}" && eq ${ANSWER.self_cert} "false" && error --from chain "self_cert=false for ${REQ.dest_host}; enable self_cert to use nested web3 host over HTTPS";
-              match ${REQ.dest_host} "*.web3.{{sn_host}}" && return "forward tcp:///:{{tls_port}}";
+              match ${REQ.dest_host} "*.web3.{{sn_host}}" && return "forward tcp:///:{{tls_port}}?proxy_protocol=v2";
               reject;

--- a/src/web3-gateway/web3_relay.yaml
+++ b/src/web3-gateway/web3_relay.yaml
@@ -147,11 +147,11 @@ stacks:
               call https-sni-probe || reject;
               map-create "REQ.ext";
               map-add "REQ.ext" "proxy_source_addr" "${REQ.source_addr}";
-              eq ${REQ.dest_host} "bns.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}";
-              eq ${REQ.dest_host} "sn.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}";
-              eq ${REQ.dest_host} "www.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}";
-              eq ${REQ.dest_host} "{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}";
-              eq ${REQ.dest_host} "web3.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}";
+              eq ${REQ.dest_host} "bns.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "sn.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "www.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}?proxy_protocol=v2";
+              eq ${REQ.dest_host} "web3.{{sn_host}}" && return "forward tcp:///{{sn_api_addr}}:{{api_tls_port}}?proxy_protocol=v2";
               map-create "QUESTION" && map-add "QUESTION" "dest_host" "${REQ.dest_host}" && map-add "QUESTION" "method" "deviceinfo.resolve_ood_by_hostname";
               call qa "web3_sn" "QUESTION";
               eq ${ANSWER.self_cert} "true" && return "forward rtcp://${ANSWER.did_hostname}/:443";

--- a/src/web3-gateway/web3_sn_api.yaml
+++ b/src/web3-gateway/web3_sn_api.yaml
@@ -38,6 +38,10 @@ servers:
 
   main_http:
     type: http
+    # The split relay appends X-Forwarded-For on cleartext HTTP. Override the
+    # parameter with the relay host's private IP/CIDR for a cross-host split.
+    trusted_upstreams:
+      - "{{sn_relay_trusted_upstream}}"
     hook_point:
       main:
         id: main
@@ -73,6 +77,10 @@ stacks:
   main_tls:
     bind: "{{api_tls_bind}}"
     protocol: tls
+    # PROXY v2 is parsed only for this direct peer. Keep the default for a
+    # same-host split; cross-host deployments must set the relay private CIDR.
+    trusted_upstreams:
+      - "{{sn_relay_trusted_upstream}}"
     hosts:
       - host: "sn.{{sn_host}}"
         cert_path: "{{sn_cer}}"


### PR DESCRIPTION
## Problem

SN `InternalRoot` methods are intentionally unauthenticated management/recovery methods, but the source boundary previously trusted an address restored from a PROXY header that TCP/TLS listeners parsed for every peer. A public client could therefore claim loopback. The split relay also failed to propagate the original source on several SN API routes.

## Changes

- keep `InternalRoot` restricted to IPv4/IPv6 loopback and reject other clients with HTTP 404 before parsing RPC
- make automatic PROXY v1/v2 parsing fail closed by default on TCP/TLS stacks
- add stack-level `trusted_upstreams` IP/CIDR configuration; only a matching direct peer may restore a PROXY source
- send PROXY v2 on every split TLS route to `sn.`, `bns.`, `web3.`, `www.`, and the apex
- trust forwarded HTTP headers only from `sn_relay_trusted_upstream`
- use the same explicit relay IP/CIDR for the split SN API TLS stack; default to same-host `127.0.0.1/32`, with private CIDR override for cross-host deployment
- add helper and TCP stack tests proving an untrusted forged loopback PROXY header is not parsed, plus loopback/private-relay positive cases

## Verification

- `cargo test --locked -p cyfs-gateway-lib proxy_protocol`
- `cargo check --locked -p web3_gateway`
- `git diff --check`

