### PR TITLE
Fix SN device self-cert reports

### DIFF
--- a/src/components/cyfs-sn/src/api/user.rs
+++ b/src/components/cyfs-sn/src/api/user.rs
@@ -3,6 +3,7 @@ use super::common::{
     RpcCallResult, SetSelfCertReq,
 };
 use super::errors::{parse_error, SnApiErrorCode};
+use crate::sn_authority::{require_sn_user_or_device, AuthContext};
 use crate::SNServer;
 use ::kRPC::{RPCErrors, RPCRequest, RPCResponse};
 use cyfs_gateway_api::SnSuccessResp;
@@ -10,17 +11,24 @@ use cyfs_gateway_api::SnSuccessResp;
 pub(crate) async fn handle_user(server: &SNServer, req: RPCRequest) -> RpcCallResult<RPCResponse> {
     match req.method.as_str() {
         "set_self_cert" => {
-            let username = require_account_username(server, &req).await?;
             let params: SetSelfCertReq = parse_params(&req)?;
-            if params.self_cert {
-                let device_did = params.device_did.as_deref().ok_or_else(|| {
-                    parse_error(
-                        SnApiErrorCode::DevicePermissionDenied,
-                        "device_did is required to enable self_cert",
-                    )
-                })?;
-                ensure_owned_runtime_device(server, username.as_str(), device_did).await?;
-            }
+            let username = match require_sn_user_or_device(server, &req).await? {
+                AuthContext::SnUser { username, .. } => {
+                    if params.self_cert {
+                        let device_did = params.device_did.as_deref().ok_or_else(|| {
+                            parse_error(
+                                SnApiErrorCode::DevicePermissionDenied,
+                                "device_did is required to enable self_cert",
+                            )
+                        })?;
+                        ensure_owned_runtime_device(server, username.as_str(), device_did).await?;
+                    }
+                    username
+                }
+                // require_sn_device has already anchored the signing key to this
+                // active zone, so the request cannot select another username.
+                AuthContext::Device { zone, .. } => zone,
+            };
             server
                 .auth_db()
                 .update_user_self_cert(username.as_str(), params.self_cert)

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -5720,6 +5720,26 @@ mod tests {
         assert_eq!(ood_info.owner_id, DEVTOKEN_USER);
         assert_eq!(ood_info.state, SnOodState::Active);
 
+        // ACME completion is reported by the registered device itself. The
+        // payload DID is not trusted; zone ownership comes from the verified
+        // device token and its registered key anchor.
+        let result = device_auth_krpc
+            .call(
+                "user.set_self_cert",
+                json!({
+                    "self_cert": true,
+                    "device_did": "did:dev:forged-request-value"
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result["code"].as_i64().unwrap(), 0);
+        let profile = account_auth_krpc
+            .call("user.get_profile", json!({}))
+            .await
+            .unwrap();
+        assert!(profile["self_cert"].as_bool().unwrap());
+
         // 越权：ood1 的设备 token 不能冒名上报 ood2。
         let err = device_token_krpc
             .call(
@@ -5804,7 +5824,7 @@ mod tests {
         assert_eq!(result["zone"].as_str().unwrap(), DEVTOKEN_USER);
         assert_eq!(result["bns_name"].as_str().unwrap(), DEVTOKEN_USER);
         assert!(result["relay_sn"].is_null());
-        assert!(!result["self_cert"].as_bool().unwrap());
+        assert!(result["self_cert"].as_bool().unwrap());
 
         // relay manager 分配后回写 relay_sn（经 auth 库，同一 sqlite 文件）；
         // 设备 token 也能读到稳定 relay 名称，供 node_daemon 检测切换。


### PR DESCRIPTION
## What changed

- allow `user.set_self_cert` to authenticate with either an SN account token or a verified device token
- derive the zone from the verified device context instead of trusting request fields
- preserve the existing account-token ownership check
- extend the device-token end-to-end test through `self_cert=true` and the account/zone projections

## Why

The ACME SN provider reports successful certificate issuance with a short-lived `aud=sn-device` token. After the SN API refactor, `user.set_self_cert` still required an account token, so the device token was decoded with the account key and failed with `invalid_token: InvalidSignature`. The certificate was installed on the client, but SN kept `self_cert=false` and rejected nested HTTPS hosts.

## Validation

- `cargo test --locked -p cyfs-sn test_sn_device_token_report_paths -- --nocapture`
- `cargo test --locked -p cyfs-sn test_sn_refactored_api_paths -- --nocapture`
- deployed the combined beta2.2 test build on the transitional SN environment
- confirmed the client automatically changed the persisted certificate state to complete and SN stored `self_cert=1`
- confirmed trusted HTTPS responses for apex, system, and systest hosts through the RTCP tunnel
