### PR TITLE
Use verified RTCP identity for SN admission

### DIFF
--- a/doc/rtcp/rtcp.md
+++ b/doc/rtcp/rtcp.md
@@ -382,6 +382,11 @@ RTCP v2 的认证锚点是双方设备的长期 Ed25519 身份；会话密钥则
 
 无论 `from_id` 使用名字还是 `did:dev`，认证成功后 RTCP 内部都会得到一个 canonical source DEV DID。这个 DEV DID 用于 nonce cache、tunnel key 和会话身份锚定；原始名字身份仍保留其逻辑语义，供日志、策略和上层业务理解。
 
+这里分成两个阶段：
+
+1. **Phase 1，RTCP 身份验证**：验证 Hello、设备文档和 tunnel token，得到 canonical `did:dev`，同时保留已经验证的逻辑文档身份、owner、zone 和 device name。
+2. **Phase 2，业务授权 hook**：`on_new_tunnel_hook_point` 的 `REQ.source_device_id` / `REQ.real_source_did` 表示 Phase 1 已验证的文档身份；名字设备可以保持 `did:bns` / `did:web` 逻辑 DID。`REQ.source_device_owner`、`REQ.source_zone_did`、`REQ.source_device_name` 承载经过验证的业务元数据。业务层可以按这些字段检查注册状态和权限，但不应重新解析文档公钥来重建另一套身份。
+
 #### 5.3.1 关于匿名访问：为什么 `did:dev:xxx` 直接放行不是漏洞
 
 第 2 条路径里，接收侧只用 `from_id` 自带的公钥验了一下 `tunnel_token` 就放行进入握手——很多人第一眼会把它当成安全漏洞。这里澄清设计意图：
@@ -501,7 +506,7 @@ IV/nonce 选择规则：
 5. 从 `Hello.my_port` 提取对端后续回连所需的 RTCP 监听端口。
 6. 现场生成一次性 X25519 密钥对 `(resp_secret, resp_public)` 和随机 `challenge`，签发 `ack_token`（`aud == "buckyos-rtcp-v2-ack"`，`peer_xpub == Hello.xpub`），并以**明文**形式把 `HelloAck { ack_token, challenge, responder_id }` 发到承载流上。
 7. 用 `(resp_secret, Hello.xpub)` 做 ECDH，走 §5.4.1 的 HKDF 派生 `(aes_key, iv)`；把承载流包成 `EncryptedStream`（responder 方向），等待 AEAD 形式的 `HelloAckConfirm` 并校验 `challenge_echo`。
-8. 只有 key-confirmation 成功后，才调用 `listener.on_new_tunnel(...)` 做准入控制。
+8. 只有 key-confirmation 成功后，才调用 `listener.on_new_tunnel(...)` 做准入控制；传给 hook 的是 Phase 1 已验证的设备文档身份及其 owner/zone/name 元数据，不是未经验证的 Hello 字符串。
 9. 准入通过后，才把这条连接包装成 tunnel，标记 `can_direct = false`，并按 canonical DEV DID 注册到 `tunnel_map`。
 10. 启动 tunnel 读循环。
 
@@ -510,7 +515,7 @@ IV/nonce 选择规则：
 - `Hello` 之后还有一次 `HelloAck`（明文）/ `HelloAckConfirm`（AEAD）的往返，必须成功才算 tunnel 建立；详见 §14.2。
 - **TCP 三次握手成功不等于 tunnel 建立成功**。当前实现的建链完成点是“协议层 key-confirmation 成功”，不是 `TcpStream::connect()` 返回。
 - `can_direct` 的设置时机也在 key-confirmation 之后，而不是刚拿到一条 TCP 连接时。
-- `Hello.from_id` / `Hello.to_id` 承载逻辑来源和逻辑目标语义；真正的身份校验会把它们解析到 canonical `did:dev` 后再比较。名字到 DEV 的转换是内部动作，不应要求调用方在协议语义上放弃 `did:web` / `did:bns`。
+- `Hello.from_id` / `Hello.to_id` 承载逻辑来源和逻辑目标语义；真正的身份校验会把它们解析到 canonical `did:dev` 后再比较。名字到 DEV 的转换是内部认证动作，不应要求调用方在协议语义上放弃 `did:web` / `did:bns`；Phase 2 可继续按已经验证的逻辑身份实施业务权限。
 - 对端后续回连端口来自 `Hello.my_port`，不是当前 TCP 连接的源端口。
 - v2 的 AES key/IV 完全派生自双方临时 X25519 密钥对，与设备长期密钥无关——即便长期 Ed25519 私钥之后被泄露，也无法解密任何已经结束的会话。
 

--- a/doc/rtcp/rtcp_on_new_tunnel_hook_point_example.md
+++ b/doc/rtcp/rtcp_on_new_tunnel_hook_point_example.md
@@ -18,9 +18,9 @@
 
 注意：
 
-- `REQ.source_device_id` 来自 RTCP 握手包里的 `hello.body.from_id`
-- 它是对端设备的 `device_config.id` 字符串
-- `REQ.source_device_owner` / `REQ.source_zone_did` / `REQ.source_device_name` 只有在对端 `Hello` 里携带并通过校验 `device_doc_jwt` 时才存在
+- `REQ.source_device_id` 是 RTCP Phase 1 已验证的设备文档身份，不是直接信任的 `hello.body.from_id` 原文；名字设备可以保持 `did:bns` / `did:web` 逻辑 DID
+- `REQ.source_device_owner` / `REQ.source_zone_did` / `REQ.source_device_name` 只有在对端 `Hello` 携带且 RTCP 成功验证 `device_doc_jwt` 时才存在
+- Phase 2 的业务策略应使用这些已验证字段检查注册状态和权限，不要重新解析 `device_doc_jwt` 的公钥来推导另一套设备身份
 - 如果你希望 `on_new_tunnel_hook_point` 使用这些语义字段，发起方的 `device_config_path` 应该指向 owner 已签名的 `device.doc.jwt`
 - 示例里的 `<真实device_id>` 需要替换成你实际设备配置里的 `id`
 
@@ -136,6 +136,7 @@ stacks:
 
 - 如果你要做强身份控制，优先使用 `REQ.source_device_id`
 - 如果你要按 owner / zone 做准入，确保对端实际发送的是 `device.doc.jwt`
+- SN 这类有设备注册表的业务可按已验证的 zone/device name 查询注册状态；canonical key DID 的派生属于 RTCP Phase 1，不属于业务 hook
 - 如果你要做临时封禁或局域网限制，再叠加 `REQ.source_addr`
 - `on_new_tunnel_hook_point` 里只做准入控制，不要把 stream 转发逻辑写进来
 - 真正的 `forward` / `server` 分发逻辑仍然放在普通 `hook_point`

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -1396,17 +1396,45 @@ impl SNServer {
     fn device_did_from_document(value: &Value) -> Option<String> {
         for key in ["did", "id"] {
             if let Some(did) = value.get(key).and_then(|v| v.as_str()) {
+                if DID::from_str(did.trim()).is_ok_and(|parsed| parsed.method == "dev") {
+                    return Some(did.trim().to_string());
+                }
+            }
+        }
+
+        let public_key_x = value
+            .get("x")
+            .and_then(|v| v.as_str())
+            .filter(|x| !x.trim().is_empty())
+            .or_else(|| {
+                value
+                    .get("verificationMethod")
+                    .or_else(|| value.get("verification_method"))
+                    .and_then(|methods| methods.as_array())
+                    .and_then(|methods| {
+                        methods.iter().find_map(|method| {
+                            method
+                                .get("publicKeyJwk")
+                                .or_else(|| method.get("public_key_jwk"))
+                                .and_then(|jwk| jwk.get("x"))
+                                .and_then(|x| x.as_str())
+                                .filter(|x| !x.trim().is_empty())
+                        })
+                    })
+            });
+        if let Some(public_key_x) = public_key_x {
+            return Some(format!("did:dev:{}", public_key_x.trim()));
+        }
+
+        for key in ["did", "id"] {
+            if let Some(did) = value.get(key).and_then(|v| v.as_str()) {
                 if !did.trim().is_empty() {
                     return Some(did.trim().to_string());
                 }
             }
         }
 
-        value
-            .get("x")
-            .and_then(|v| v.as_str())
-            .filter(|x| !x.trim().is_empty())
-            .map(|x| format!("did:dev:{}", x.trim()))
+        None
     }
 
     fn registered_device_not_found(did: &str) -> String {
@@ -2726,6 +2754,43 @@ mod tests {
     const ANVIL_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     const ANVIL_ADDRESS: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+    #[test]
+    fn device_did_from_scoped_document_uses_verification_key() {
+        let document = json!({
+            "id": "did:bns:ood1.alice",
+            "verificationMethod": [{
+                "id": "#main_key",
+                "controller": "did:bns:ood1.alice",
+                "publicKeyJwk": {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "canonical-device-key"
+                }
+            }]
+        });
+
+        assert_eq!(
+            SNServer::device_did_from_document(&document).as_deref(),
+            Some("did:dev:canonical-device-key")
+        );
+    }
+
+    #[test]
+    fn device_did_from_document_keeps_explicit_dev_did() {
+        let document = json!({
+            "did": "did:dev:explicit-device-key",
+            "id": "did:bns:ood1.alice",
+            "verificationMethod": [{
+                "publicKeyJwk": { "x": "other-device-key" }
+            }]
+        });
+
+        assert_eq!(
+            SNServer::device_did_from_document(&document).as_deref(),
+            Some("did:dev:explicit-device-key")
+        );
+    }
 
     fn test_bns_system_info() -> BnsSystemInfo {
         BnsSystemInfo {

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -1159,24 +1159,16 @@ impl SNServer {
         }
 
         if let Some(key) = self.registered_device_key_from_did(did).await? {
-            let canonical_did = self.canonical_device_did_from_scoped_did(did).await?;
+            // RTCP Phase 1 has already authenticated the logical device
+            // document. Phase 2 only applies the SN business registration and
+            // state policy to that verified identity; it must not re-resolve
+            // the document and derive another identity from its key material.
             if let Some(view) = self
                 .device_info_db
                 .get_device_state_by_name(key.zone.as_str(), key.device_name.as_str())
                 .await
                 .map_err(|e| RPCErrors::ReasonError(e.to_string()))?
             {
-                if let Some(canonical_did) = canonical_did.as_deref() {
-                    if canonical_did != view.did.as_str() {
-                        return Err(RPCErrors::ParseRequestError(
-                            Self::registered_device_did_mismatch(
-                                did,
-                                canonical_did,
-                                view.did.as_str(),
-                            ),
-                        ));
-                    }
-                }
                 let registered_did = view.did.clone();
                 return self
                     .ood_info_from_device_state(registered_did.as_str(), view)
@@ -1189,17 +1181,6 @@ impl SNServer {
                 .await
                 .map_err(|e| RPCErrors::ReasonError(e.to_string()))?
             {
-                if let Some(canonical_did) = canonical_did.as_deref() {
-                    if canonical_did != device_info.did.as_str() {
-                        return Err(RPCErrors::ParseRequestError(
-                            Self::registered_device_did_mismatch(
-                                did,
-                                canonical_did,
-                                device_info.did.as_str(),
-                            ),
-                        ));
-                    }
-                }
                 let registered_did = device_info.did.clone();
                 return self
                     .ood_info_from_legacy_device(registered_did.as_str(), device_info)
@@ -1346,119 +1327,15 @@ impl SNServer {
         value.trim().trim_end_matches('.').to_ascii_lowercase()
     }
 
-    async fn canonical_device_did_from_scoped_did(
-        &self,
-        did: &str,
-    ) -> Result<Option<String>, RPCErrors> {
-        let did = match DID::from_str(did) {
-            Ok(did) => did,
-            Err(_) => return Ok(None),
-        };
-        if did.method != "bns" && did.method != "web" {
-            return Ok(None);
-        }
-        let did_string = did.to_string();
-
-        let resolution = match self
-            .did_resolver
-            .resolve(SnDidResolveRequest::new(
-                did,
-                Some("doc".to_string()),
-                None,
-                SnDidResolverProfile::InternalZoneResolver,
-            ))
-            .await
-        {
-            Ok(resolution) => resolution,
-            Err(e) => {
-                debug!(
-                    "skip canonical device DID check for {}: resolver failed: {}",
-                    did_string, e
-                );
-                return Ok(None);
-            }
-        };
-
-        let value = match resolution.document.to_json_value() {
-            Ok(value) => value,
-            Err(e) => {
-                debug!(
-                    "skip canonical device DID check for {}: document decode failed: {}",
-                    did_string, e
-                );
-                return Ok(None);
-            }
-        };
-
-        Ok(Self::device_did_from_document(&value))
-    }
-
-    fn device_did_from_document(value: &Value) -> Option<String> {
-        for key in ["did", "id"] {
-            if let Some(did) = value.get(key).and_then(|v| v.as_str()) {
-                if DID::from_str(did.trim()).is_ok_and(|parsed| parsed.method == "dev") {
-                    return Some(did.trim().to_string());
-                }
-            }
-        }
-
-        let public_key_x = value
-            .get("x")
-            .and_then(|v| v.as_str())
-            .filter(|x| !x.trim().is_empty())
-            .or_else(|| {
-                value
-                    .get("verificationMethod")
-                    .or_else(|| value.get("verification_method"))
-                    .and_then(|methods| methods.as_array())
-                    .and_then(|methods| {
-                        methods.iter().find_map(|method| {
-                            method
-                                .get("publicKeyJwk")
-                                .or_else(|| method.get("public_key_jwk"))
-                                .and_then(|jwk| jwk.get("x"))
-                                .and_then(|x| x.as_str())
-                                .filter(|x| !x.trim().is_empty())
-                        })
-                    })
-            });
-        if let Some(public_key_x) = public_key_x {
-            return Some(format!("did:dev:{}", public_key_x.trim()));
-        }
-
-        for key in ["did", "id"] {
-            if let Some(did) = value.get(key).and_then(|v| v.as_str()) {
-                if !did.trim().is_empty() {
-                    return Some(did.trim().to_string());
-                }
-            }
-        }
-
-        None
-    }
-
     fn registered_device_not_found(did: &str) -> String {
         format!(
             "registered device not found for source_device_id={did}; \
              deviceinfo.resolve_ood_by_did checks the exact DID first, then for \
              did:bns:<device>.<zone> or did:web:<device>.<domain> checks the \
-             registered device binding by zone and device_name. Prefer passing the \
-             canonical did:dev device DID after registration; scoped BNS/Web device \
-             DIDs are accepted as compatibility aliases. Verify the SN sqlite \
-             devices/device_indexes tables contain a device registered for the same \
-             public key, device name, and zone."
-        )
-    }
-
-    fn registered_device_did_mismatch(
-        query_did: &str,
-        resolved_did: &str,
-        registered_did: &str,
-    ) -> String {
-        format!(
-            "registered device DID mismatch for source_device_id={query_did}; \
-             scoped DID resolves to canonical device DID {resolved_did}, but the \
-             registered device binding points to {registered_did}."
+             registered device binding by zone and device_name. RTCP Phase 1 \
+             authenticates the presented device document; this Phase 2 lookup only \
+             applies the stored registration/state policy. Verify the SN sqlite \
+             devices/device_indexes tables contain that zone and device name."
         )
     }
 
@@ -2754,43 +2631,6 @@ mod tests {
     const ANVIL_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     const ANVIL_ADDRESS: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
-
-    #[test]
-    fn device_did_from_scoped_document_uses_verification_key() {
-        let document = json!({
-            "id": "did:bns:ood1.alice",
-            "verificationMethod": [{
-                "id": "#main_key",
-                "controller": "did:bns:ood1.alice",
-                "publicKeyJwk": {
-                    "kty": "OKP",
-                    "crv": "Ed25519",
-                    "x": "canonical-device-key"
-                }
-            }]
-        });
-
-        assert_eq!(
-            SNServer::device_did_from_document(&document).as_deref(),
-            Some("did:dev:canonical-device-key")
-        );
-    }
-
-    #[test]
-    fn device_did_from_document_keeps_explicit_dev_did() {
-        let document = json!({
-            "did": "did:dev:explicit-device-key",
-            "id": "did:bns:ood1.alice",
-            "verificationMethod": [{
-                "publicKeyJwk": { "x": "other-device-key" }
-            }]
-        });
-
-        assert_eq!(
-            SNServer::device_did_from_document(&document).as_deref(),
-            Some("did:dev:explicit-device-key")
-        );
-    }
 
     fn test_bns_system_info() -> BnsSystemInfo {
         BnsSystemInfo {


### PR DESCRIPTION
## What changed

- remove the SN Phase 2 re-resolution of scoped device documents and the duplicate JWK-to-`did:dev` derivation
- use the RTCP Phase 1 verified logical identity to find the stored device registration by zone and device name
- continue enforcing registered state, zone ownership, and `self_cert` policy from `SnDeviceInfoDB`
- document the Phase 1 identity verification and Phase 2 business authorization boundary

## Why

RTCP already validates the device document and tunnel token before invoking `on_new_tunnel_hook_point`. A named device can therefore reach the hook as a verified `did:bns` or `did:web` logical identity, with verified owner/zone/device metadata. Re-resolving that document in SN business logic and deriving another key DID duplicates Phase 1 and can reject a valid identity because of document representation differences.

Phase 2 should apply the SN registration and state policy to the verified identity, not build a second identity verifier.

## Validation

- `cargo test --locked -p cyfs-sn test_sn_refactored_api_paths -- --nocapture`
  - covers exact `did:dev` lookup and verified scoped `did:bns:<device>.<zone>` lookup
- `git diff --check`

