### PR TITLE
Fix SN ACME DNS challenge lifecycle

### DIFF
--- a/src/apps/cyfs_gateway/src/acme_sn_provider.rs
+++ b/src/apps/cyfs_gateway/src/acme_sn_provider.rs
@@ -15,6 +15,10 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Weak};
 
+const SN_DNS_CHALLENGE_TTL_SECS: u32 = 60;
+const SN_DNS_PROPAGATION_DELAY: std::time::Duration =
+    std::time::Duration::from_secs(SN_DNS_CHALLENGE_TTL_SECS as u64 + 5);
+
 pub struct AcmeSnProviderFactory {
     data_path: PathBuf,
 }
@@ -347,11 +351,15 @@ impl DnsProvider for AcmeSnProvider {
                     "domain": domain,
                     "record_type": "TXT",
                     "record": key_hash,
-                    "ttl": 600
+                    "ttl": SN_DNS_CHALLENGE_TTL_SECS
                 }),
             )
             .await
             .map_err(|e| anyhow!("add_dns_record failed.{:?}", e))?;
+            // The SN zone advertises a 60-second negative cache TTL. Wait for
+            // cached NXDOMAIN responses to expire before ACME starts DNS-01
+            // validation.
+            tokio::time::sleep(SN_DNS_PROPAGATION_DELAY).await;
         } else if op == "del_challenge" {
             let mut has_cert = false;
             if let Some(acme_mgr) = self.weak_acme_mgr.upgrade() {

--- a/src/apps/cyfs_gateway/src/acme_sn_provider.rs
+++ b/src/apps/cyfs_gateway/src/acme_sn_provider.rs
@@ -141,6 +141,10 @@ impl DnsProviderFactory for AcmeSnProviderFactory {
             config.access_token,
         ))
     }
+
+    fn propagation_delay(&self) -> std::time::Duration {
+        SN_DNS_PROPAGATION_DELAY
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -356,10 +360,6 @@ impl DnsProvider for AcmeSnProvider {
             )
             .await
             .map_err(|e| anyhow!("add_dns_record failed.{:?}", e))?;
-            // The SN zone advertises a 60-second negative cache TTL. Wait for
-            // cached NXDOMAIN responses to expire before ACME starts DNS-01
-            // validation.
-            tokio::time::sleep(SN_DNS_PROPAGATION_DELAY).await;
         } else if op == "del_challenge" {
             let mut has_cert = false;
             if let Some(acme_mgr) = self.weak_acme_mgr.upgrade() {

--- a/src/apps/web3_gateway/src/acme_sn_provider.rs
+++ b/src/apps/web3_gateway/src/acme_sn_provider.rs
@@ -15,6 +15,10 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Weak};
 
+const SN_DNS_CHALLENGE_TTL_SECS: u32 = 60;
+const SN_DNS_PROPAGATION_DELAY: std::time::Duration =
+    std::time::Duration::from_secs(SN_DNS_CHALLENGE_TTL_SECS as u64 + 5);
+
 pub struct AcmeSnProviderFactory {
     data_path: PathBuf,
 }
@@ -324,11 +328,15 @@ impl DnsProvider for AcmeSnProvider {
                     "domain": domain,
                     "record_type": "TXT",
                     "record": key_hash,
-                    "ttl": 600
+                    "ttl": SN_DNS_CHALLENGE_TTL_SECS
                 }),
             )
             .await
             .map_err(|e| anyhow!("add_dns_record failed.{:?}", e))?;
+            // The SN zone advertises a 60-second negative cache TTL. Wait for
+            // cached NXDOMAIN responses to expire before ACME starts DNS-01
+            // validation.
+            tokio::time::sleep(SN_DNS_PROPAGATION_DELAY).await;
         } else if op == "del_challenge" {
             let mut has_cert = false;
             if let Some(acme_mgr) = self.weak_acme_mgr.upgrade() {

--- a/src/apps/web3_gateway/src/acme_sn_provider.rs
+++ b/src/apps/web3_gateway/src/acme_sn_provider.rs
@@ -117,6 +117,10 @@ impl DnsProviderFactory for AcmeSnProviderFactory {
             config.access_token,
         ))
     }
+
+    fn propagation_delay(&self) -> std::time::Duration {
+        SN_DNS_PROPAGATION_DELAY
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -333,10 +337,6 @@ impl DnsProvider for AcmeSnProvider {
             )
             .await
             .map_err(|e| anyhow!("add_dns_record failed.{:?}", e))?;
-            // The SN zone advertises a 60-second negative cache TTL. Wait for
-            // cached NXDOMAIN responses to expire before ACME starts DNS-01
-            // validation.
-            tokio::time::sleep(SN_DNS_PROPAGATION_DELAY).await;
         } else if op == "del_challenge" {
             let mut has_cert = false;
             if let Some(acme_mgr) = self.weak_acme_mgr.upgrade() {

--- a/src/components/cyfs-acme/src/acme_client.rs
+++ b/src/components/cyfs-acme/src/acme_client.rs
@@ -216,9 +216,11 @@ impl AcmeAccount {
 
 #[derive(Debug, Deserialize)]
 struct AcmeError {
+    #[serde(rename = "type")]
     type_: String,
     detail: String,
-    status: u16,
+    #[serde(default)]
+    status: Option<u16>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -317,6 +319,10 @@ impl AcmeOrderSession {
                 );
                 // 准备挑战响应
                 let resp_challenge = self.responder.respond_challenge(&challenges).await?;
+                // Track the prepared response before asking the ACME server to
+                // validate it. This guarantees Drop cleans it up when
+                // verification or authorization polling fails.
+                self.respond_logs.push(resp_challenge.clone());
 
                 // 通知服务器验证挑战
                 self.client
@@ -327,8 +333,6 @@ impl AcmeOrderSession {
                 self.client
                     .poll_authorization(auth_url, directory.clone())
                     .await?;
-
-                self.respond_logs.push(resp_challenge.clone());
             }
         }
 
@@ -803,11 +807,22 @@ impl AcmeClient {
                     continue;
                 }
                 "invalid" => {
+                    let challenge_errors = authz
+                        .challenges
+                        .iter()
+                        .filter_map(|challenge| challenge.error.as_ref())
+                        .map(|error| format!("{}: {}", error.type_, error.detail))
+                        .collect::<Vec<_>>();
+                    let detail = if challenge_errors.is_empty() {
+                        "no challenge error detail returned".to_string()
+                    } else {
+                        challenge_errors.join("; ")
+                    };
                     error!(
-                        "poll acme authorization failed, client: {}, auth_url: {}, status: {}",
-                        self, auth_url, authz.status
+                        "poll acme authorization failed, client: {}, auth_url: {}, status: {}, detail: {}",
+                        self, auth_url, authz.status, detail
                     );
-                    return Err(anyhow::anyhow!("Authorization failed"));
+                    return Err(anyhow::anyhow!("Authorization failed: {}", detail));
                 }
                 _ => {
                     error!(
@@ -1276,6 +1291,8 @@ struct ChallengeResponse {
     url: String,
     status: String,
     token: String,
+    #[serde(default)]
+    error: Option<AcmeError>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1297,6 +1314,32 @@ struct AccountResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn authz_response_parses_challenge_error() {
+        let authz: AuthzResponse = serde_json::from_value(serde_json::json!({
+            "identifier": {"type": "dns", "value": "example.com"},
+            "status": "invalid",
+            "expires": "2026-07-24T00:00:00Z",
+            "challenges": [{
+                "type": "dns-01",
+                "url": "https://acme.example/challenge/1",
+                "status": "invalid",
+                "token": "challenge-token",
+                "error": {
+                    "type": "urn:ietf:params:acme:error:dns",
+                    "detail": "TXT record was not found",
+                    "status": 400
+                }
+            }]
+        }))
+        .unwrap();
+
+        let error = authz.challenges[0].error.as_ref().unwrap();
+        assert_eq!(error.type_, "urn:ietf:params:acme:error:dns");
+        assert_eq!(error.detail, "TXT record was not found");
+        assert_eq!(error.status, Some(400));
+    }
 
     #[test]
     fn post_as_get_uses_empty_payload() {

--- a/src/components/cyfs-acme/src/acme_client.rs
+++ b/src/components/cyfs-acme/src/acme_client.rs
@@ -5,7 +5,7 @@ use base64::Engine;
 use openssl::{
     pkey::{PKey, Private},
     rsa::Rsa,
-    x509::{X509NameBuilder, X509ReqBuilder, extension::SubjectAlternativeName},
+    x509::{extension::SubjectAlternativeName, X509NameBuilder, X509ReqBuilder},
 };
 use rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256};
 use reqwest;
@@ -216,11 +216,16 @@ impl AcmeAccount {
 
 #[derive(Debug, Deserialize)]
 struct AcmeError {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default = "default_acme_problem_type")]
     type_: String,
-    detail: String,
+    #[serde(default)]
+    detail: Option<String>,
     #[serde(default)]
     status: Option<u16>,
+}
+
+fn default_acme_problem_type() -> String {
+    "about:blank".to_string()
 }
 
 #[derive(Debug, Deserialize)]
@@ -249,6 +254,9 @@ struct AcmeClientInner {
 #[async_trait::async_trait]
 pub trait AcmeChallengeResponder: Send + Sync {
     async fn respond_challenge<'a>(&self, challenges: &'a [Challenge]) -> Result<&'a Challenge>;
+    fn propagation_delay(&self, _challenge: &Challenge) -> Duration {
+        Duration::ZERO
+    }
     fn revert_challenge(&self, challenge: &Challenge);
 }
 
@@ -323,6 +331,15 @@ impl AcmeOrderSession {
                 // validate it. This guarantees Drop cleans it up when
                 // verification or authorization polling fails.
                 self.respond_logs.push(resp_challenge.clone());
+
+                let propagation_delay = self.responder.propagation_delay(resp_challenge);
+                if !propagation_delay.is_zero() {
+                    info!(
+                        "wait {:?} for ACME challenge propagation: {}",
+                        propagation_delay, resp_challenge.domain
+                    );
+                    tokio::time::sleep(propagation_delay).await;
+                }
 
                 // 通知服务器验证挑战
                 self.client
@@ -811,7 +828,12 @@ impl AcmeClient {
                         .challenges
                         .iter()
                         .filter_map(|challenge| challenge.error.as_ref())
-                        .map(|error| format!("{}: {}", error.type_, error.detail))
+                        .map(|error| match error.detail.as_deref() {
+                            Some(detail) if !detail.is_empty() => {
+                                format!("{}: {}", error.type_, detail)
+                            }
+                            _ => error.type_.clone(),
+                        })
                         .collect::<Vec<_>>();
                     let detail = if challenge_errors.is_empty() {
                         "no challenge error detail returned".to_string()
@@ -1337,8 +1359,30 @@ mod tests {
 
         let error = authz.challenges[0].error.as_ref().unwrap();
         assert_eq!(error.type_, "urn:ietf:params:acme:error:dns");
-        assert_eq!(error.detail, "TXT record was not found");
+        assert_eq!(error.detail.as_deref(), Some("TXT record was not found"));
         assert_eq!(error.status, Some(400));
+    }
+
+    #[test]
+    fn authz_response_accepts_challenge_error_without_optional_problem_members() {
+        let authz: AuthzResponse = serde_json::from_value(serde_json::json!({
+            "identifier": {"type": "dns", "value": "example.com"},
+            "status": "invalid",
+            "expires": "2026-07-24T00:00:00Z",
+            "challenges": [{
+                "type": "dns-01",
+                "url": "https://acme.example/challenge/1",
+                "status": "invalid",
+                "token": "challenge-token",
+                "error": {}
+            }]
+        }))
+        .unwrap();
+
+        let error = authz.challenges[0].error.as_ref().unwrap();
+        assert_eq!(error.type_, "about:blank");
+        assert_eq!(error.detail, None);
+        assert_eq!(error.status, None);
     }
 
     #[test]

--- a/src/components/cyfs-acme/src/cert_mgr.rs
+++ b/src/components/cyfs-acme/src/cert_mgr.rs
@@ -1051,6 +1051,10 @@ pub trait DnsProviderFactory: Send + Sync + 'static {
         acme_mgr: Weak<AcmeCertManager>,
         params: serde_json::Value,
     ) -> Result<DnsProviderRef>;
+
+    fn propagation_delay(&self) -> Duration {
+        Duration::ZERO
+    }
 }
 pub type DnsProviderFactoryRef = Arc<dyn DnsProviderFactory>;
 
@@ -1104,6 +1108,7 @@ pub struct AcmeCertManager {
     challenge_certs: Mutex<HashMap<String, Arc<sign::CertifiedKey>>>,
     http_challenges: Mutex<HashMap<String, String>>,
     dns_providers: RwLock<HashMap<String, DnsProviderRef>>,
+    dns_provider_propagation_delays: RwLock<HashMap<String, Duration>>,
 }
 
 pub type AcmeCertManagerRef = Arc<AcmeCertManager>;
@@ -1227,6 +1232,7 @@ impl AcmeCertManager {
         let acme_client = AcmeClient::new(account, config.acme_server.clone()).await?;
 
         let mut dns_providers = HashMap::<String, DnsProviderRef>::new();
+        let mut dns_provider_propagation_delays = HashMap::<String, Duration>::new();
         let manager = AcmeCertManagerRef::new(Self {
             config: config.clone(),
             acme_client,
@@ -1236,6 +1242,7 @@ impl AcmeCertManager {
             challenge_certs: Mutex::new(Default::default()),
             http_challenges: Mutex::new(Default::default()),
             dns_providers: RwLock::new(dns_providers.clone()),
+            dns_provider_propagation_delays: RwLock::new(dns_provider_propagation_delays.clone()),
         });
 
         if let Some(dns_providers_config) = &config.dns_providers {
@@ -1250,10 +1257,14 @@ impl AcmeCertManager {
             for (name, provider_config) in dns_providers_config.iter() {
                 let factory = { DNS_PROVIDER_FACTORYS.read().unwrap().get(name).cloned() };
                 if let Some(factory) = factory {
+                    let propagation_delay = factory.propagation_delay();
                     let provider = factory
                         .create(Arc::downgrade(&manager), provider_config.clone())
                         .await?;
                     dns_providers.insert(name.clone(), provider);
+                    if !propagation_delay.is_zero() {
+                        dns_provider_propagation_delays.insert(name.clone(), propagation_delay);
+                    }
                 } else {
                     if provider_manager.is_some() {
                         let provider = ExternalDnsProvider::new(
@@ -1268,6 +1279,11 @@ impl AcmeCertManager {
         }
         {
             manager.dns_providers.write().unwrap().extend(dns_providers);
+            manager
+                .dns_provider_propagation_delays
+                .write()
+                .unwrap()
+                .extend(dns_provider_propagation_delays);
         }
 
         {
@@ -1481,34 +1497,61 @@ impl AcmeCertManager {
         providers.get(provider_name).cloned()
     }
 
+    fn get_dns_provider_for_cert(&self, cert_stub: &CertStub) -> Result<DnsProviderRef> {
+        let provider_data = cert_stub
+            .inner
+            .acme_item
+            .data
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("dns challenge provider params is empty"))?;
+        let provider_info: DnsProviderInfo = serde_json::from_value(provider_data.clone())
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "parse plugin data {} failed: {}",
+                    serde_json::to_string(&provider_data).unwrap_or_default(),
+                    e
+                )
+            })?;
+
+        self.get_provider(provider_info.dns_provider.as_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "dns challenge provider {} not exists",
+                    provider_info.dns_provider
+                )
+            })
+    }
+
+    pub(crate) fn challenge_propagation_delay(&self, challenge: &Challenge) -> Duration {
+        if !matches!(&challenge.data, ChallengeData::Dns01 { .. }) {
+            return Duration::ZERO;
+        }
+
+        let cert_stub = {
+            let certs = self.certs.read().unwrap();
+            certs.get(challenge.domain.as_str()).cloned()
+        };
+        cert_stub
+            .as_ref()
+            .and_then(|stub| stub.inner.acme_item.data.clone())
+            .and_then(|data| serde_json::from_value::<DnsProviderInfo>(data).ok())
+            .and_then(|info| {
+                self.dns_provider_propagation_delays
+                    .read()
+                    .unwrap()
+                    .get(info.dns_provider.as_str())
+                    .copied()
+            })
+            .unwrap_or(Duration::ZERO)
+    }
+
     async fn call_dns_provider(
         &self,
         cert_stub: &CertStub,
         key_hash: &str,
         op: &str,
     ) -> Result<()> {
-        if cert_stub.inner.acme_item.data.is_none() {
-            return Err(anyhow::anyhow!("dns challenge provider params is empty"));
-        }
-
-        let provider_data = cert_stub.inner.acme_item.data.clone().unwrap();
-        let provider_info: DnsProviderInfo = serde_json::from_value(provider_data.clone())
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "parse plugin data {} failed: {}",
-                    serde_json::to_string(&provider_data).unwrap_or("".to_string()),
-                    e
-                )
-            })?;
-
-        let provider = self.get_provider(provider_info.dns_provider.as_str());
-        if provider.is_none() {
-            return Err(anyhow::anyhow!(
-                "dns challenge provider {} not exists",
-                provider_info.dns_provider
-            ));
-        }
-        let provider = provider.unwrap().clone();
+        let provider = self.get_dns_provider_for_cert(cert_stub)?;
 
         let domain = if cert_stub.inner.acme_item.domain.starts_with("*.") {
             format!("_acme-challenge{}", &cert_stub.inner.acme_item.domain[1..])

--- a/src/components/cyfs-acme/src/default_challenge_responder.rs
+++ b/src/components/cyfs-acme/src/default_challenge_responder.rs
@@ -26,6 +26,13 @@ impl AcmeChallengeResponder for DefaultChallengeResponder {
         }
     }
 
+    fn propagation_delay(&self, challenge: &Challenge) -> std::time::Duration {
+        self.cert_mgr
+            .upgrade()
+            .map(|cert_mgr| cert_mgr.challenge_propagation_delay(challenge))
+            .unwrap_or(std::time::Duration::ZERO)
+    }
+
     fn revert_challenge(&self, challenge: &Challenge) {
         if let Some(cert_mgr) = self.cert_mgr.upgrade() {
             cert_mgr.revert_challenge(challenge);


### PR DESCRIPTION
## What changed

- make ACME problem `type` default to `about:blank` and make `detail`/`status` optional
- add coverage for a compliant challenge error with no optional problem members
- keep SN TXT provisioning immediate, but declare its 65-second propagation delay as provider-factory metadata
- record the prepared challenge in `AcmeOrderSession` before waiting, then sleep before asking the ACME server to validate
- keep cleanup behavior shared by `cyfs_gateway` and `web3_gateway`

## Why

ACME challenge errors are problem documents whose `type` and `detail` members may be omitted. Requiring them can fail authorization deserialization before diagnostics are reported.

The propagation sleep previously ran inside the SN provider before `respond_challenge` returned. Cancelling the order during that sleep left the session cleanup log empty and leaked the TXT record. Waiting after cleanup registration makes cancellation run the existing revert path.

## Validation

- `cargo test --locked -p cyfs-acme` (5 passed)
- `cargo check --locked -p cyfs_gateway -p web3_gateway`
- `git diff --check`

