### PR TITLE
Return authoritative NODATA for unsupported CAA

### DIFF
--- a/src/components/cyfs-dns/src/dns_server.rs
+++ b/src/components/cyfs-dns/src/dns_server.rs
@@ -212,6 +212,16 @@ fn is_authoritative_loopback_suppressed_error(err: &ServerError) -> bool {
         && err.to_string().contains(DNS_AUTH_LOOPBACK_SUPPRESSED_MSG)
 }
 
+fn is_authoritative_unsupported_record_error(err: &ServerError) -> bool {
+    matches!(
+        err.code(),
+        ServerErrorCode::InvalidParam | ServerErrorCode::ProcessChainError
+    ) && err
+        .to_string()
+        .to_ascii_lowercase()
+        .contains("unsupported record type")
+}
+
 /// Trait for handling incoming requests, and providing a message response.
 #[async_trait::async_trait]
 trait DnsRequestHandler<'q, 'a, Answers, NameServers, Soa, Additionals>:
@@ -805,7 +815,8 @@ impl ProcessChainDnsServer {
                                 let is_core_zone_type =
                                     is_core_authoritative_record_type(query_type);
 
-                                if is_authoritative_loopback_suppressed_error(&e)
+                                if (is_authoritative_loopback_suppressed_error(&e)
+                                    || is_authoritative_unsupported_record_error(&e))
                                     && !is_core_zone_type
                                 {
                                     return self.authoritative_zone_response_to_buffer(
@@ -1029,6 +1040,10 @@ mod tests {
                     IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
                 )),
                 name_client::RecordType::AAAA => Ok(NameInfo::from_address_vec(name, vec![])),
+                name_client::RecordType::CAA => Err(cyfs_gateway_lib::server_err!(
+                    ServerErrorCode::InvalidParam,
+                    "unsupported record type CAA"
+                )),
                 _ => Err(cyfs_gateway_lib::server_err!(
                     ServerErrorCode::NotFound,
                     "record type not found"
@@ -1104,7 +1119,8 @@ hook_point:
         .unwrap()
     }
 
-    async fn create_authoritative_notfound_test_server() -> ProcessChainDnsServer {
+    async fn create_authoritative_notfound_test_server(
+    ) -> (ProcessChainDnsServer, Arc<ServerManager>) {
         let server_mgr = Arc::new(ServerManager::new());
         server_mgr
             .add_server(Server::NameServer(Arc::new(EmptyAaaaNameServer)))
@@ -1122,7 +1138,7 @@ hook_point:
           call resolve ${REQ.name} ${REQ.record_type} empty_aaaa && return;
         "#;
         let config: DnsServerConfig = serde_yaml_ng::from_str(config).unwrap();
-        ProcessChainDnsServer::create_server(
+        let server = ProcessChainDnsServer::create_server(
             config.id,
             Arc::downgrade(&server_mgr),
             Some(Arc::new(GlobalProcessChains::new())),
@@ -1132,7 +1148,8 @@ hook_point:
             Some(Arc::new(JsExternalsManager::new())),
         )
         .await
-        .unwrap()
+        .unwrap();
+        (server, server_mgr)
     }
 
     async fn create_authoritative_loopback_fallback_test_server() -> ProcessChainDnsServer {
@@ -1246,7 +1263,7 @@ hook_point:
 
     #[tokio::test]
     async fn test_authoritative_web3_zone_apex_missing_record_returns_nodata_with_soa() {
-        let server = create_authoritative_notfound_test_server().await;
+        let (server, _server_mgr) = create_authoritative_notfound_test_server().await;
 
         let mut message = Message::new();
         let name = Name::from_str("web3.buckyos.ai.").unwrap();
@@ -1271,6 +1288,30 @@ hook_point:
     #[tokio::test]
     async fn test_authoritative_web3_zone_subdomain_caa_loopback_fallback_returns_nodata() {
         let server = create_authoritative_loopback_fallback_test_server().await;
+
+        let mut message = Message::new();
+        let name = Name::from_str("wugren2026.web3.buckyos.ai.").unwrap();
+        let query = Query::query(name, RecordType::CAA);
+        message.add_query(query);
+
+        let data = server
+            .serve_datagram(
+                message.to_vec().unwrap().as_slice(),
+                DatagramInfo::new(None),
+            )
+            .await
+            .unwrap();
+        let resp = Message::from_vec(data.as_slice()).unwrap();
+        assert_eq!(resp.response_code(), ResponseCode::NoError);
+        assert!(resp.header().authoritative());
+        assert_eq!(resp.answers().len(), 0);
+        assert_eq!(resp.name_servers().len(), 1);
+        assert_eq!(resp.name_servers()[0].record_type(), RecordType::SOA);
+    }
+
+    #[tokio::test]
+    async fn test_authoritative_web3_zone_subdomain_unsupported_caa_returns_nodata() {
+        let (server, _server_mgr) = create_authoritative_notfound_test_server().await;
 
         let mut message = Message::new();
         let name = Name::from_str("wugren2026.web3.buckyos.ai.").unwrap();

--- a/src/components/cyfs-dns/src/dns_server.rs
+++ b/src/components/cyfs-dns/src/dns_server.rs
@@ -587,6 +587,39 @@ impl ProcessChainDnsServer {
         }
     }
 
+    async fn authoritative_name_exists(
+        &self,
+        request: &Request,
+        dst_addr: Option<String>,
+    ) -> ServerResult<bool> {
+        let request_info = request
+            .request_info()
+            .map_err(into_server_err!(ServerErrorCode::BadRequest))?;
+        let mut probe = Message::new();
+        probe
+            .set_id(request.id())
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Query)
+            .set_recursion_desired(request.recursion_desired())
+            .add_query(Query::query(
+                request_info.query.name().into(),
+                hickory_server::proto::rr::RecordType::A,
+            ));
+        let probe_bytes = probe
+            .to_vec()
+            .map_err(into_server_err!(ServerErrorCode::EncodeError))?;
+        let mut decoder = BinDecoder::new(probe_bytes.as_slice());
+        let probe_message = MessageRequest::read(&mut decoder)
+            .map_err(into_server_err!(ServerErrorCode::BadRequest))?;
+        let probe_request = Request::new(probe_message, request.src(), Protocol::Udp);
+
+        match self.handle_request(&probe_request, dst_addr).await {
+            Ok(_) => Ok(true),
+            Err(err) if err.code() == ServerErrorCode::NotFound => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
     async fn handle_request<'a>(
         &self,
         request: &Request,
@@ -802,7 +835,7 @@ impl ProcessChainDnsServer {
                     .map_err(into_server_err!(ServerErrorCode::BadRequest))?;
                 let query_name = request_info.query.name().to_string();
                 let query_type = request_info.query.query_type().to_string();
-                match self.handle_request(&request, dst_addr).await {
+                match self.handle_request(&request, dst_addr.clone()).await {
                     Ok(response) => Ok(response),
                     Err(e) => {
                         if let Ok(request_info) = request.request_info() {
@@ -815,8 +848,7 @@ impl ProcessChainDnsServer {
                                 let is_core_zone_type =
                                     is_core_authoritative_record_type(query_type);
 
-                                if (is_authoritative_loopback_suppressed_error(&e)
-                                    || is_authoritative_unsupported_record_error(&e))
+                                if is_authoritative_loopback_suppressed_error(&e)
                                     && !is_core_zone_type
                                 {
                                     return self.authoritative_zone_response_to_buffer(
@@ -825,6 +857,38 @@ impl ProcessChainDnsServer {
                                         vec![],
                                         vec![zone_soa_record(&zone)],
                                     );
+                                }
+
+                                if is_authoritative_unsupported_record_error(&e)
+                                    && !is_core_zone_type
+                                {
+                                    match self
+                                        .authoritative_name_exists(&request, dst_addr.clone())
+                                        .await
+                                    {
+                                        Ok(true) => {
+                                            return self.authoritative_zone_response_to_buffer(
+                                                &request,
+                                                ResponseCode::NoError,
+                                                vec![],
+                                                vec![zone_soa_record(&zone)],
+                                            );
+                                        }
+                                        Ok(false) => {
+                                            return self.authoritative_zone_response_to_buffer(
+                                                &request,
+                                                ResponseCode::NXDomain,
+                                                vec![],
+                                                vec![zone_soa_record(&zone)],
+                                            );
+                                        }
+                                        Err(probe_err) => {
+                                            warn!(
+                                                "failed to confirm authoritative name existence for {}: {}",
+                                                query_name, probe_err
+                                            );
+                                        }
+                                    }
                                 }
 
                                 if is_zone_apex && !is_core_zone_type {
@@ -1020,6 +1084,8 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
+    const EXISTING_WEB3_NAME: &str = "wugren2026.web3.buckyos.ai";
+
     struct EmptyAaaaNameServer;
 
     #[async_trait]
@@ -1035,9 +1101,19 @@ mod tests {
             _from_ip: Option<IpAddr>,
         ) -> ServerResult<NameInfo> {
             match record_type.unwrap_or_default() {
-                name_client::RecordType::A => Ok(NameInfo::from_address(
-                    name,
-                    IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+                name_client::RecordType::A
+                    if name
+                        .trim_end_matches('.')
+                        .eq_ignore_ascii_case(EXISTING_WEB3_NAME) =>
+                {
+                    Ok(NameInfo::from_address(
+                        name,
+                        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+                    ))
+                }
+                name_client::RecordType::A => Err(cyfs_gateway_lib::server_err!(
+                    ServerErrorCode::NotFound,
+                    "name not found"
                 )),
                 name_client::RecordType::AAAA => Ok(NameInfo::from_address_vec(name, vec![])),
                 name_client::RecordType::CAA => Err(cyfs_gateway_lib::server_err!(
@@ -1327,6 +1403,30 @@ hook_point:
             .unwrap();
         let resp = Message::from_vec(data.as_slice()).unwrap();
         assert_eq!(resp.response_code(), ResponseCode::NoError);
+        assert!(resp.header().authoritative());
+        assert_eq!(resp.answers().len(), 0);
+        assert_eq!(resp.name_servers().len(), 1);
+        assert_eq!(resp.name_servers()[0].record_type(), RecordType::SOA);
+    }
+
+    #[tokio::test]
+    async fn test_authoritative_web3_zone_nonexistent_subdomain_caa_returns_nxdomain() {
+        let (server, _server_mgr) = create_authoritative_notfound_test_server().await;
+
+        let mut message = Message::new();
+        let name = Name::from_str("missing.web3.buckyos.ai.").unwrap();
+        let query = Query::query(name, RecordType::CAA);
+        message.add_query(query);
+
+        let data = server
+            .serve_datagram(
+                message.to_vec().unwrap().as_slice(),
+                DatagramInfo::new(None),
+            )
+            .await
+            .unwrap();
+        let resp = Message::from_vec(data.as_slice()).unwrap();
+        assert_eq!(resp.response_code(), ResponseCode::NXDomain);
         assert!(resp.header().authoritative());
         assert_eq!(resp.answers().len(), 0);
         assert_eq!(resp.name_servers().len(), 1);


### PR DESCRIPTION
## What changed

- keep authoritative `NOERROR/NODATA` with SOA for an existing managed name that has no supported CAA conversion
- before converting the unsupported-record error, probe the same authoritative route for name existence
- return authoritative `NXDOMAIN` with SOA when the name does not exist
- add separate regression coverage for existing-name NODATA and nonexistent-name NXDOMAIN

## Why

The SN resolver rejects unsupported CAA types before resolving the hostname. Treating every such error as NODATA incorrectly asserts that arbitrary names inside the managed zone exist. ACME needs NODATA for an existing name without CAA, while normal DNS semantics still require NXDOMAIN for an unknown name.

## Validation

- `cargo test --locked -p cyfs-dns caa` (7 passed)
- `rustfmt --edition 2021 --check src/components/cyfs-dns/src/dns_server.rs`
- `git diff --check`

