### PR TITLE
支持 TCP/TLS 进程内跨 Stack 流转交

### DIFF
--- a/src/apps/cyfs_gateway/Cargo.toml
+++ b/src/apps/cyfs_gateway/Cargo.toml
@@ -56,6 +56,7 @@ httpdate = "1.0"
 
 [dev-dependencies]
 tempfile.workspace = true
+rcgen.workspace = true
 hyper = { version = "1.8", features = ["full"] }
 hyper-util.workspace = true
 http-body-util.workspace = true

--- a/src/apps/cyfs_gateway/src/gateway.rs
+++ b/src/apps/cyfs_gateway/src/gateway.rs
@@ -303,17 +303,21 @@ fn build_stack_context(
     global_collection_manager: Option<GlobalCollectionManagerRef>,
     js_externals: Option<JsExternalsManagerRef>,
     self_cert_mgr: SelfCertMgrRef,
+    stack_manager: StackManagerWeakRef,
 ) -> StackResult<Arc<dyn StackContext>> {
     match protocol {
-        StackProtocol::Tcp => Ok(Arc::new(TcpStackContext::new(
-            servers.clone(),
-            tunnel_manager.clone(),
-            limiter_manager.clone(),
-            stat_manager.clone(),
-            global_process_chains.clone(),
-            global_collection_manager.clone(),
-            js_externals.clone(),
-        ))),
+        StackProtocol::Tcp => Ok(Arc::new(
+            TcpStackContext::new(
+                servers.clone(),
+                tunnel_manager.clone(),
+                limiter_manager.clone(),
+                stat_manager.clone(),
+                global_process_chains.clone(),
+                global_collection_manager.clone(),
+                js_externals.clone(),
+            )
+            .with_stack_manager(stack_manager.clone()),
+        )),
         StackProtocol::Udp => Ok(Arc::new(UdpStackContext::new(
             servers.clone(),
             tunnel_manager.clone(),
@@ -332,16 +336,19 @@ fn build_stack_context(
             global_collection_manager.clone(),
             js_externals.clone(),
         ))),
-        StackProtocol::Tls => Ok(Arc::new(TlsStackContext::new(
-            servers.clone(),
-            tunnel_manager.clone(),
-            limiter_manager.clone(),
-            stat_manager.clone(),
-            self_cert_mgr.clone(),
-            global_process_chains.clone(),
-            global_collection_manager.clone(),
-            js_externals.clone(),
-        ))),
+        StackProtocol::Tls => Ok(Arc::new(
+            TlsStackContext::new(
+                servers.clone(),
+                tunnel_manager.clone(),
+                limiter_manager.clone(),
+                stat_manager.clone(),
+                self_cert_mgr.clone(),
+                global_process_chains.clone(),
+                global_collection_manager.clone(),
+                js_externals.clone(),
+            )
+            .with_stack_manager(stack_manager.clone()),
+        )),
         StackProtocol::Quic => Ok(Arc::new(QuicStackContext::new(
             servers.clone(),
             tunnel_manager.clone(),
@@ -945,6 +952,7 @@ impl GatewayFactory {
                 Some(global_collections.clone()),
                 Some(js_externals.clone()),
                 self_cert_manager.clone(),
+                Arc::downgrade(&stack_manager),
             )?;
             let stack = self
                 .stack_factory
@@ -3007,6 +3015,7 @@ impl Gateway {
                 Some(global_collections.clone()),
                 Some(js_externals.clone()),
                 self_cert_manager.clone(),
+                Arc::downgrade(&self.stack_manager),
             )?;
             exist_stacks.insert(stack_config.id().clone());
             if let Some(stack) = self.stack_manager.get_stack(stack_config.id().as_str()) {

--- a/src/apps/cyfs_gateway/tests/test_cyfs_gateway.rs
+++ b/src/apps/cyfs_gateway/tests/test_cyfs_gateway.rs
@@ -144,6 +144,11 @@ mod tests {
         listener.local_addr().unwrap().port()
     }
 
+    async fn allocate_free_udp_port() -> u16 {
+        let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        socket.local_addr().unwrap().port()
+    }
+
     async fn start_echo_server() -> u16 {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -173,6 +178,79 @@ mod tests {
         });
 
         port
+    }
+
+    async fn start_bns_readiness_server() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(value) => value,
+                    Err(_) => break,
+                };
+                tokio::spawn(async move {
+                    let service = hyper::service::service_fn(
+                        |request: hyper::Request<hyper::body::Incoming>| async move {
+                            let request = request.into_body().collect().await.unwrap().to_bytes();
+                            let request: serde_json::Value =
+                                serde_json::from_slice(request.as_ref()).unwrap();
+                            let seq = request
+                                .get("sys")
+                                .and_then(|value| value.get(0))
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            let body = serde_json::to_vec(&json!({
+                                "result": {
+                                    "ok": true,
+                                    "result": {
+                                        "ready": true,
+                                        "chain_id": 31337,
+                                        "contract_address": "0x2222222222222222222222222222222222222222"
+                                    },
+                                    "error": null
+                                },
+                                "sys": [seq]
+                            }))
+                            .unwrap();
+                            Ok::<_, std::convert::Infallible>(hyper::Response::new(Full::new(
+                                Bytes::from(body),
+                            )))
+                        },
+                    );
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await;
+                });
+            }
+        });
+
+        port
+    }
+
+    async fn assert_call_stack_response(scheme: &str, host: &str, port: u16) {
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .danger_accept_invalid_certs(true)
+            .resolve(host, SocketAddr::from(([127, 0, 0, 1], port)))
+            .build()
+            .unwrap();
+        let url = format!("{scheme}://{host}/");
+        let response = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                match client.get(url.as_str()).send().await {
+                    Ok(response) => break response,
+                    Err(_) => {
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    }
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+        assert_eq!(response.text().await.unwrap(), "www.buckyos.com");
     }
 
     async fn read_socks_addr(stream: &mut TcpStream, atyp: u8) -> Result<(), std::io::Error> {
@@ -294,10 +372,26 @@ mod tests {
 
         let echo_direct_port = start_echo_server().await;
         let echo_proxy_port = start_echo_server().await;
+        let bns_rpc_port = start_bns_readiness_server().await;
+        let test1_port = allocate_free_port().await;
+        let test2_port = allocate_free_port().await;
+        let dns_port = allocate_free_udp_port().await;
+        let ptcp_entry_port = allocate_free_port().await;
+        let ptcp_mix_port = allocate_free_port().await;
+        let dispatch_port = allocate_free_port().await;
         let reject_port = allocate_free_port().await;
         let socks_stack_port = allocate_free_port().await;
         let upstream_socks_stack_port = allocate_free_port().await;
+        let call_stack_tcp_target_port = allocate_free_port().await;
+        let call_stack_tls_target_port = allocate_free_port().await;
+        let call_stack_tcp_to_tcp_port = allocate_free_port().await;
+        let call_stack_tcp_to_tls_port = allocate_free_port().await;
+        let call_stack_tls_to_tcp_port = allocate_free_port().await;
         let control_server_port = allocate_free_port().await;
+        let test1_addr = SocketAddr::from(([127, 0, 0, 1], test1_port));
+        let test2_url = format!("http://127.0.0.1:{test2_port}/");
+        let dispatch_port_string = dispatch_port.to_string();
+        let dispatch_addr = SocketAddr::from(([127, 0, 0, 1], dispatch_port));
         let control_server = format!("http://127.0.0.1:{control_server_port}");
 
         let config = include_str!("test_cyfs_gateway.yaml");
@@ -369,6 +463,54 @@ function test_js_hook(context, host) {
             "{{upstream_socks_stack_port}}",
             upstream_socks_stack_port.to_string().as_str(),
         );
+        let config = config.replace("{{test1_port}}", test1_port.to_string().as_str());
+        let config = config.replace("{{test2_port}}", test2_port.to_string().as_str());
+        let config = config.replace("{{dns_port}}", dns_port.to_string().as_str());
+        let config = config.replace("{{ptcp_entry_port}}", ptcp_entry_port.to_string().as_str());
+        let config = config.replace("{{ptcp_mix_port}}", ptcp_mix_port.to_string().as_str());
+        let config = config.replace(
+            "{{call_stack_tcp_target_port}}",
+            call_stack_tcp_target_port.to_string().as_str(),
+        );
+        let config = config.replace(
+            "{{call_stack_tls_target_port}}",
+            call_stack_tls_target_port.to_string().as_str(),
+        );
+        let config = config.replace(
+            "{{call_stack_tcp_to_tcp_port}}",
+            call_stack_tcp_to_tcp_port.to_string().as_str(),
+        );
+        let config = config.replace(
+            "{{call_stack_tcp_to_tls_port}}",
+            call_stack_tcp_to_tls_port.to_string().as_str(),
+        );
+        let config = config.replace(
+            "{{call_stack_tls_to_tcp_port}}",
+            call_stack_tls_to_tcp_port.to_string().as_str(),
+        );
+        let call_stack_cert_dir = tempfile::TempDir::new().unwrap();
+        let call_stack_cert_path = call_stack_cert_dir.path().join("cert.pem");
+        let call_stack_key_path = call_stack_cert_dir.path().join("key.pem");
+        let call_stack_cert = rcgen::generate_simple_self_signed(vec![
+            "tcp-call-tls.buckyos.com".to_string(),
+            "tls-call-tcp.buckyos.com".to_string(),
+        ])
+        .unwrap();
+        std::fs::write(&call_stack_cert_path, call_stack_cert.cert.pem()).unwrap();
+        std::fs::write(
+            &call_stack_key_path,
+            call_stack_cert.signing_key.serialize_pem(),
+        )
+        .unwrap();
+        let config = config.replace(
+            "{{call_stack_tls_cert_path}}",
+            call_stack_cert_path.to_str().unwrap(),
+        );
+        let config = config.replace(
+            "{{call_stack_tls_key_path}}",
+            call_stack_key_path.to_str().unwrap(),
+        );
+        let config = config.replace("{{bns_rpc_port}}", bns_rpc_port.to_string().as_str());
         let config = config.replace(
             "{{control_server_port}}",
             control_server_port.to_string().as_str(),
@@ -394,11 +536,28 @@ function test_js_hook(context, host) {
 
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
+        assert_call_stack_response(
+            "http",
+            "tcp-call-tcp.buckyos.com",
+            call_stack_tcp_to_tcp_port,
+        )
+        .await;
+        assert_call_stack_response(
+            "https",
+            "tcp-call-tls.buckyos.com",
+            call_stack_tcp_to_tls_port,
+        )
+        .await;
+        assert_call_stack_response(
+            "https",
+            "tls-call-tcp.buckyos.com",
+            call_stack_tls_to_tcp_port,
+        )
+        .await;
+
         {
             //用tokio库创建一个tcpstream
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -451,9 +610,7 @@ function test_js_hook(context, host) {
 
         {
             //用tokio库创建一个tcpstream
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -484,9 +641,7 @@ function test_js_hook(context, host) {
 
         {
             //用tokio库创建一个tcpstream
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -523,9 +678,7 @@ function test_js_hook(context, host) {
 
         {
             //用tokio库创建一个tcpstream
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -552,9 +705,7 @@ function test_js_hook(context, host) {
         }
 
         {
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -584,9 +735,7 @@ function test_js_hook(context, host) {
         }
 
         {
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -618,9 +767,7 @@ function test_js_hook(context, host) {
         }
 
         {
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let body = json!({
                 "method": "admin.clear_state_by_active_code",
@@ -651,7 +798,7 @@ function test_js_hook(context, host) {
         }
 
         {
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18084")
+            let stream = tokio::net::TcpStream::connect(("127.0.0.1", ptcp_mix_port))
                 .await
                 .unwrap();
 
@@ -678,14 +825,12 @@ function test_js_hook(context, host) {
 
         {
             let socket = tokio::net::TcpSocket::new_v4().unwrap();
-            socket
-                .bind(SocketAddr::from_str("127.0.0.1:18123").unwrap())
-                .unwrap();
+            socket.bind(SocketAddr::from(([127, 0, 0, 1], 0))).unwrap();
             let stream = socket
-                .connect(SocketAddr::from_str("127.0.0.1:18082").unwrap())
+                .connect(SocketAddr::from(([127, 0, 0, 1], ptcp_entry_port)))
                 .await
                 .unwrap();
-            let expected_port = 18123;
+            let expected_port = stream.local_addr().unwrap().port();
 
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
                 .handshake(TokioIo::new(stream))
@@ -734,7 +879,7 @@ function test_js_hook(context, host) {
 
         {
             let name_server_configs = vec![NameServerConfig::new(
-                SocketAddr::from_str("127.0.0.1:9545").unwrap(),
+                SocketAddr::from(([127, 0, 0, 1], dns_port)),
                 Protocol::Udp,
             )];
             let server_config = ResolverConfig::from_parts(None, vec![], name_server_configs);
@@ -773,9 +918,7 @@ function test_js_hook(context, host) {
             let ret = cyfs_cmd_client.add_rule("stack:test1", r#"http-probe && eq ${REQ.dest_host} "test.buckyos.com" && call-server www.buckyos.com;"#).await;
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -812,9 +955,7 @@ function test_js_hook(context, host) {
             let ret = cyfs_cmd_client.add_rule("stack:test1", r#"http-probe && eq ${REQ.dest_host} "test2.buckyos.com" && call-server www.buckyos.com;"#).await;
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             // 用hyper构造一个http请求
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -854,9 +995,7 @@ function test_js_hook(context, host) {
             let ret = cyfs_cmd_client.add_rule("server:www_dir:main:test2", r#"starts-with ${REQ.path} "/sn" && rewrite ${REQ.path} "/sn*" "/*" && call-server sn.http;"#).await;
             assert!(ret.is_err());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let body = json!({
                 "method": "admin.clear_state_by_active_code",
@@ -901,9 +1040,7 @@ function test_js_hook(context, host) {
                 .await;
             assert!(ret.is_err());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let body = json!({
                 "method": "admin.clear_state_by_active_code",
@@ -944,9 +1081,7 @@ function test_js_hook(context, host) {
             let ret = cyfs_cmd_client.append_rule("server:www_dir:main:test2", r#"starts-with ${REQ.path} "/sn" && rewrite ${REQ.path} "/sn*" "/*" && call-server sn.http;"#).await;
             assert!(ret.is_err());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let body = json!({
                 "method": "admin.clear_state_by_active_code",
@@ -986,9 +1121,7 @@ function test_js_hook(context, host) {
                 .await;
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let body = json!({
                 "method": "admin.clear_state_by_active_code",
@@ -1026,9 +1159,7 @@ function test_js_hook(context, host) {
             let ret = cyfs_cmd_client.set_rule("server:www.buckyos.com:main:test2", r#"starts-with ${REQ.path} "/snsn" && rewrite ${REQ.path} "/snsn*" "/*" && call-server sn.http;"#).await;
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let body = json!({
                 "method": "admin.clear_state_by_active_code",
@@ -1076,9 +1207,7 @@ function test_js_hook(context, host) {
                 .await;
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
                 .handshake(TokioIo::new(stream))
@@ -1125,9 +1254,7 @@ function test_js_hook(context, host) {
                 .await;
             assert!(ret.is_err());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
                 .handshake(TokioIo::new(stream))
@@ -1156,15 +1283,13 @@ function test_js_hook(context, host) {
                 .add_router(
                     Some("server:www.buckyos.com"),
                     "/reverse/",
-                    "http://127.0.0.1:18081/",
+                    test2_url.as_str(),
                 )
                 .await;
             ret.as_ref().unwrap();
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
                 .handshake(TokioIo::new(stream))
@@ -1198,14 +1323,12 @@ function test_js_hook(context, host) {
                 .remove_router(
                     Some("server:www.buckyos.com"),
                     "/reverse/",
-                    "http://127.0.0.1:18081/",
+                    test2_url.as_str(),
                 )
                 .await;
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:18080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(test1_addr).await.unwrap();
 
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
                 .handshake(TokioIo::new(stream))
@@ -1231,13 +1354,15 @@ function test_js_hook(context, host) {
                 read_login_token(CONTROL_SERVER),
             );
             let ret = cyfs_cmd_client
-                .add_dispatch("19080", "127.0.0.1:18080", None)
+                .add_dispatch(
+                    dispatch_port_string.as_str(),
+                    test1_addr.to_string().as_str(),
+                    None,
+                )
                 .await;
             assert!(ret.is_ok());
 
-            let stream = tokio::net::TcpStream::connect("127.0.0.1:19080")
-                .await
-                .unwrap();
+            let stream = tokio::net::TcpStream::connect(dispatch_addr).await.unwrap();
 
             let body = json!({
                 "method": "admin.clear_state_by_active_code",
@@ -1272,10 +1397,12 @@ function test_js_hook(context, host) {
                 control_server.as_str(),
                 read_login_token(CONTROL_SERVER),
             );
-            let ret = cyfs_cmd_client.remove_dispatch("19080", None).await;
+            let ret = cyfs_cmd_client
+                .remove_dispatch(dispatch_port_string.as_str(), None)
+                .await;
             assert!(ret.is_ok());
 
-            let ret = tokio::net::TcpStream::connect("127.0.0.1:19080").await;
+            let ret = tokio::net::TcpStream::connect(dispatch_addr).await;
             assert!(ret.is_err());
         }
 

--- a/src/apps/cyfs_gateway/tests/test_cyfs_gateway.yaml
+++ b/src/apps/cyfs_gateway/tests/test_cyfs_gateway.yaml
@@ -39,7 +39,7 @@ stacks:
     bind: 127.0.0.1:{{control_server_port}}
 
   test1:
-    bind: 0.0.0.0:18080
+    bind: 0.0.0.0:{{test1_port}}
     protocol: tcp
     io_dump_file: {{test_io_dump}}
     hook_point:
@@ -60,7 +60,7 @@ stacks:
               reject;
 
   test2:
-    bind: 0.0.0.0:18081
+    bind: 0.0.0.0:{{test2_port}}
     protocol: tcp
     hook_point:
       main:
@@ -71,6 +71,84 @@ stacks:
             block: |
               exec --lib global_test1;
               http-probe && call-server ${REQ.dest_host};
+              reject;
+
+  call_stack_tcp_target:
+    bind: 127.0.0.1:{{call_stack_tcp_target_port}}
+    protocol: tcp
+    hook_point:
+      main:
+        priority: 1
+        blocks:
+          default:
+            priority: 1
+            block: |
+              eq ${REQ.dest_host} "tcp-call-tcp.buckyos.com" && call-server www.buckyos.com;
+              eq ${REQ.dest_host} "tls-call-tcp.buckyos.com" && call-server www.buckyos.com;
+              reject;
+
+  call_stack_tls_target:
+    bind: 127.0.0.1:{{call_stack_tls_target_port}}
+    protocol: tls
+    hosts:
+      - host: tcp-call-tls.buckyos.com
+        cert_path: {{call_stack_tls_cert_path}}
+        key_path: {{call_stack_tls_key_path}}
+    alpn_protocols:
+      - http/1.1
+    hook_point:
+      main:
+        priority: 1
+        blocks:
+          default:
+            priority: 1
+            block: |
+              eq ${REQ.dest_host} "tcp-call-tls.buckyos.com" && call-server www.buckyos.com;
+              reject;
+
+  call_stack_tcp_to_tcp:
+    bind: 127.0.0.1:{{call_stack_tcp_to_tcp_port}}
+    protocol: tcp
+    hook_point:
+      main:
+        priority: 1
+        blocks:
+          default:
+            priority: 1
+            block: |
+              http-probe && eq ${REQ.dest_host} "tcp-call-tcp.buckyos.com" && call-stack call_stack_tcp_target;
+              reject;
+
+  call_stack_tcp_to_tls:
+    bind: 127.0.0.1:{{call_stack_tcp_to_tls_port}}
+    protocol: tcp
+    hook_point:
+      main:
+        priority: 1
+        blocks:
+          default:
+            priority: 1
+            block: |
+              https-sni-probe && eq ${REQ.dest_host} "tcp-call-tls.buckyos.com" && call-stack call_stack_tls_target;
+              reject;
+
+  call_stack_tls_to_tcp:
+    bind: 127.0.0.1:{{call_stack_tls_to_tcp_port}}
+    protocol: tls
+    hosts:
+      - host: tls-call-tcp.buckyos.com
+        cert_path: {{call_stack_tls_cert_path}}
+        key_path: {{call_stack_tls_key_path}}
+    alpn_protocols:
+      - http/1.1
+    hook_point:
+      main:
+        priority: 1
+        blocks:
+          default:
+            priority: 1
+            block: |
+              eq ${REQ.dest_host} "tls-call-tcp.buckyos.com" && call-stack call_stack_tcp_target;
               reject;
 
   socks_stack:
@@ -98,7 +176,7 @@ stacks:
               call-server upstream_socks;
 
   test3:
-    bind: 0.0.0.0:9545
+    bind: 0.0.0.0:{{dns_port}}
     protocol: udp
     transparent: false
     hook_point:
@@ -111,7 +189,7 @@ stacks:
               call-server main_dns;
 
   test_ptcp_entry:
-    bind: 0.0.0.0:18082
+    bind: 0.0.0.0:{{ptcp_entry_port}}
     protocol: tcp
     hook_point:
       main:
@@ -120,11 +198,11 @@ stacks:
           default:
             priority: 1
             block: |
-              http-probe && forward "ptcp://${REQ.source_addr}/127.0.0.1:18084";
+              http-probe && forward "ptcp://${REQ.source_addr}/127.0.0.1:{{ptcp_mix_port}}";
               reject;
 
   test_ptcp_mix:
-    bind: 0.0.0.0:18084
+    bind: 0.0.0.0:{{ptcp_mix_port}}
     protocol: tcp
     hook_point:
       main:
@@ -147,14 +225,14 @@ servers:
           default:
             priority: 1
             block: |
-              starts-with ${REQ.path} "/api" && rewrite ${REQ.path} "/api*" "*" && map-add REQ host www.buckyos.com && forward http://127.0.0.1:18081;
+              starts-with ${REQ.path} "/api" && rewrite ${REQ.path} "/api*" "*" && map-add REQ host www.buckyos.com && forward http://127.0.0.1:{{test2_port}};
       main1:
         priority: 1
         blocks:
           default:
             priority: 1
             block: |
-              starts-with ${REQ.path} "/test_return" && rewrite ${REQ.path} "/test_return*" "*" && map-add REQ host www.buckyos.com && return "forward http://127.0.0.1:18081";
+              starts-with ${REQ.path} "/test_return" && rewrite ${REQ.path} "/test_return*" "*" && map-add REQ host www.buckyos.com && return "forward http://127.0.0.1:{{test2_port}}";
               starts-with ${REQ.path} "/sn" && rewrite ${REQ.path} "/sn*" "/*" && call-server sn.http;
 
           default1:
@@ -250,6 +328,9 @@ servers:
     boot_jwt: "eyJhbGciOiJFZERTQSJ9.eyJvb2RzIjpbInNuIl0sImV4cCI6MjA1ODgzODkzOX0.SGem2FBRB0H2TcRWBRJCsCg5PYXzHW9X9853UChV_qzWHHhKxunZ-emotSnr9HufjL7avGEos1ifRjl9KTrzBg"
     owner_pkx: "qJdNEtscIYwTo-I0K7iPEt_UZdBDRd4r16jdBfNR0tM"
     device_jwt: ["eyJhbGciOiJFZERTQSJ9.eyJuIjoic24iLCJ4IjoiRlB2WTNXWFB4dVdQWUZ1d09ZMFFiaDBPNy1oaEtyNnRhMWpUY1g5T1JQSSIsImV4cCI6MjA1ODgzODkzOX0._YKR0y6E4JQJXDEG12WWFfY1pXyxtdSuigERZQXphnQAarDM02JIoXLNtad80U7T7lO_A4z_HbNDRJ9hMGKhCA"]
+    bns_rpc_url: http://127.0.0.1:{{bns_rpc_port}}
+    bns_evm:
+      controller_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     db_type: sqlite
     db_path: {{sn_db}}
 

--- a/src/apps/web3_gateway/src/gateway.rs
+++ b/src/apps/web3_gateway/src/gateway.rs
@@ -303,17 +303,21 @@ fn build_stack_context(
     global_collection_manager: Option<GlobalCollectionManagerRef>,
     js_externals: Option<JsExternalsManagerRef>,
     self_cert_mgr: SelfCertMgrRef,
+    stack_manager: StackManagerWeakRef,
 ) -> StackResult<Arc<dyn StackContext>> {
     match protocol {
-        StackProtocol::Tcp => Ok(Arc::new(TcpStackContext::new(
-            servers.clone(),
-            tunnel_manager.clone(),
-            limiter_manager.clone(),
-            stat_manager.clone(),
-            global_process_chains.clone(),
-            global_collection_manager.clone(),
-            js_externals.clone(),
-        ))),
+        StackProtocol::Tcp => Ok(Arc::new(
+            TcpStackContext::new(
+                servers.clone(),
+                tunnel_manager.clone(),
+                limiter_manager.clone(),
+                stat_manager.clone(),
+                global_process_chains.clone(),
+                global_collection_manager.clone(),
+                js_externals.clone(),
+            )
+            .with_stack_manager(stack_manager.clone()),
+        )),
         StackProtocol::Udp => Ok(Arc::new(UdpStackContext::new(
             servers.clone(),
             tunnel_manager.clone(),
@@ -332,16 +336,19 @@ fn build_stack_context(
             global_collection_manager.clone(),
             js_externals.clone(),
         ))),
-        StackProtocol::Tls => Ok(Arc::new(TlsStackContext::new(
-            servers.clone(),
-            tunnel_manager.clone(),
-            limiter_manager.clone(),
-            stat_manager.clone(),
-            self_cert_mgr.clone(),
-            global_process_chains.clone(),
-            global_collection_manager.clone(),
-            js_externals.clone(),
-        ))),
+        StackProtocol::Tls => Ok(Arc::new(
+            TlsStackContext::new(
+                servers.clone(),
+                tunnel_manager.clone(),
+                limiter_manager.clone(),
+                stat_manager.clone(),
+                self_cert_mgr.clone(),
+                global_process_chains.clone(),
+                global_collection_manager.clone(),
+                js_externals.clone(),
+            )
+            .with_stack_manager(stack_manager.clone()),
+        )),
         StackProtocol::Quic => Ok(Arc::new(QuicStackContext::new(
             servers.clone(),
             tunnel_manager.clone(),
@@ -945,6 +952,7 @@ impl GatewayFactory {
                 Some(global_collections.clone()),
                 Some(js_externals.clone()),
                 self_cert_manager.clone(),
+                Arc::downgrade(&stack_manager),
             )?;
             let stack = self
                 .stack_factory
@@ -3007,6 +3015,7 @@ impl Gateway {
                 Some(global_collections.clone()),
                 Some(js_externals.clone()),
                 self_cert_manager.clone(),
+                Arc::downgrade(&self.stack_manager),
             )?;
             exist_stacks.insert(stack_config.id().clone());
             if let Some(stack) = self.stack_manager.get_stack(stack_config.id().as_str()) {

--- a/src/components/cyfs-gateway-lib/src/cmds/mod.rs
+++ b/src/components/cyfs-gateway-lib/src/cmds/mod.rs
@@ -8,6 +8,7 @@ mod redirect;
 mod server;
 mod set_limit;
 mod set_stat;
+mod stack;
 mod verify_jwt;
 
 use crate::{CmdQa, ServerManagerWeakRef};
@@ -24,6 +25,7 @@ pub use redirect::*;
 pub use server::*;
 pub use set_limit::*;
 pub use set_stat::*;
+pub use stack::*;
 use std::sync::Arc;
 pub use verify_jwt::*;
 
@@ -123,6 +125,13 @@ pub fn get_external_commands(
         Arc::new(Box::new(server_command) as Box<dyn ExternalCommand>),
     ));
 
+    let stack_command = CallStack::new();
+    let name = stack_command.name().to_owned();
+    cmds.push((
+        name,
+        Arc::new(Box::new(stack_command) as Box<dyn ExternalCommand>),
+    ));
+
     let qa_command = CmdQa::new(server_manager);
     let name = qa_command.name().to_owned();
     cmds.push((
@@ -148,5 +157,6 @@ mod tests {
 
         assert!(names.iter().any(|name| name == "verify-jwt"));
         assert!(names.iter().any(|name| name == "parse-cookie"));
+        assert!(names.iter().any(|name| name == "call-stack"));
     }
 }

--- a/src/components/cyfs-gateway-lib/src/cmds/stack.rs
+++ b/src/components/cyfs-gateway-lib/src/cmds/stack.rs
@@ -1,0 +1,115 @@
+use clap::{Arg, Command};
+use cyfs_process_chain::*;
+
+pub struct CallStack {
+    name: String,
+    cmd: Command,
+}
+
+impl CallStack {
+    pub fn new() -> Self {
+        let cmd = Command::new("call-stack")
+            .about("Hand off the current ordered stream to a stack")
+            .after_help(
+                r#"
+Examples:
+    call-stack main_tls
+"#,
+            )
+            .arg(
+                Arg::new("stack_id")
+                    .help("Target stack ID")
+                    .index(1)
+                    .required(true),
+            );
+        Self {
+            name: "call-stack".to_string(),
+            cmd,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+#[async_trait::async_trait]
+impl ExternalCommand for CallStack {
+    fn help(&self, name: &str, help_type: CommandHelpType) -> String {
+        assert_eq!(self.cmd.get_name(), name);
+        command_help(help_type, &self.cmd)
+    }
+
+    fn check(&self, args: &CommandArgs) -> Result<(), String> {
+        self.cmd
+            .clone()
+            .try_get_matches_from(args.as_str_list())
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = format!("Invalid call-stack command: {:?}, {}", args, e);
+                error!("{}", msg);
+                msg
+            })
+    }
+
+    async fn exec(
+        &self,
+        _context: &Context,
+        args: &[CollectionValue],
+        _origin_args: &CommandArgs,
+    ) -> Result<CommandResult, String> {
+        let mut str_args = Vec::with_capacity(args.len());
+        for arg in args {
+            if !arg.is_string() {
+                return Err(format!(
+                    "Invalid argument type: expected string, got {:?}",
+                    arg
+                ));
+            }
+            str_args.push(arg.as_str().unwrap());
+        }
+        let matches = self
+            .cmd
+            .clone()
+            .try_get_matches_from(&str_args)
+            .map_err(|e| format!("Invalid call-stack command: {:?}, {}", args, e))?;
+        let stack_id = matches
+            .get_one::<String>("stack_id")
+            .ok_or_else(|| "stack_id is required".to_string())?;
+        Ok(CommandResult::return_with_string(
+            CommandControlLevel::Lib,
+            format!("stack {}", stack_id),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn literal(value: &str) -> CommandArg {
+        CommandArg::Literal(value.to_string())
+    }
+
+    #[test]
+    fn test_call_stack_check_accepts_one_target() {
+        let command = CallStack::new();
+        let args = CommandArgs::new(vec![literal("call-stack"), literal("main_tls")]);
+        command.check(&args).unwrap();
+    }
+
+    #[test]
+    fn test_call_stack_check_rejects_missing_or_extra_target() {
+        let command = CallStack::new();
+        assert!(command
+            .check(&CommandArgs::new(vec![literal("call-stack")]))
+            .is_err());
+        assert!(command
+            .check(&CommandArgs::new(vec![
+                literal("call-stack"),
+                literal("main_tls"),
+                literal("extra"),
+            ]))
+            .is_err());
+    }
+}

--- a/src/components/cyfs-gateway-lib/src/stack/mod.rs
+++ b/src/components/cyfs-gateway-lib/src/stack/mod.rs
@@ -41,6 +41,9 @@ pub enum StackErrorCode {
     ListenFailed,
     AlreadyExists,
     BindUnmatched,
+    StackNotFound,
+    IncompatibleStack,
+    StackHandoffCycle,
 }
 pub type StackResult<T> = sfo_result::Result<T, StackErrorCode>;
 pub type StackError = sfo_result::Error<StackErrorCode>;

--- a/src/components/cyfs-gateway-lib/src/stack/stack.rs
+++ b/src/components/cyfs-gateway-lib/src/stack/stack.rs
@@ -1,7 +1,11 @@
-use crate::{StackErrorCode, StackResult, stack_err};
+use crate::{StackErrorCode, StackResult, StreamInfo, stack_err};
 use as_any::AsAny;
+use buckyos_kit::AsyncStream;
+use cyfs_process_chain::{CollectionValue, EnvRef, StreamRequest};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Weak;
 use std::sync::{Arc, Mutex};
 
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
@@ -57,6 +61,175 @@ pub trait StackContext: AsAny + Send + Sync {
     fn stack_protocol(&self) -> StackProtocol;
 }
 
+#[derive(Clone)]
+pub struct StackStreamContext {
+    pub ingress_stack_id: String,
+    pub route: Vec<String>,
+    pub conn_source_addr: Option<SocketAddr>,
+    pub source_addr: Option<SocketAddr>,
+    pub real_source_addr: Option<SocketAddr>,
+    pub dest_addr: Option<SocketAddr>,
+    pub dest_host: Option<String>,
+    pub dest_port: u16,
+    pub app_protocol: Option<String>,
+    pub dest_url: Option<String>,
+    pub source_mac: Option<String>,
+    pub source_hostname: Option<String>,
+    pub source_device_id: Option<String>,
+    pub source_app_id: Option<String>,
+    pub source_user_id: Option<String>,
+}
+
+impl StackStreamContext {
+    pub fn from_request(ingress_stack_id: impl Into<String>, request: &StreamRequest) -> Self {
+        let ingress_stack_id = ingress_stack_id.into();
+        Self {
+            route: vec![ingress_stack_id.clone()],
+            ingress_stack_id,
+            conn_source_addr: request.conn_source_addr,
+            source_addr: request.source_addr,
+            real_source_addr: request.real_source_addr,
+            dest_addr: request.dest_addr,
+            dest_host: request.dest_host.clone(),
+            dest_port: request.dest_port,
+            app_protocol: request.app_protocol.clone(),
+            dest_url: request.dest_url.clone(),
+            source_mac: request.source_mac.clone(),
+            source_hostname: request.source_hostname.clone(),
+            source_device_id: request.source_device_id.clone(),
+            source_app_id: request.source_app_id.clone(),
+            source_user_id: request.source_user_id.clone(),
+        }
+    }
+
+    pub fn create_request(&self, stream: Box<dyn AsyncStream>) -> StreamRequest {
+        let mut request = StreamRequest::new(
+            stream,
+            self.dest_addr
+                .or(self.source_addr)
+                .unwrap_or_else(|| "0.0.0.0:0".parse().unwrap()),
+        );
+        request.dest_port = self.dest_port;
+        request.dest_host = self.dest_host.clone();
+        request.dest_addr = self.dest_addr;
+        request.app_protocol = self.app_protocol.clone();
+        request.dest_url = self.dest_url.clone();
+        request.source_addr = self.source_addr;
+        request.conn_source_addr = self.conn_source_addr;
+        request.real_source_addr = self.real_source_addr;
+        request.source_mac = self.source_mac.clone();
+        request.source_hostname = self.source_hostname.clone();
+        request.source_device_id = self.source_device_id.clone();
+        request.source_app_id = self.source_app_id.clone();
+        request.source_user_id = self.source_user_id.clone();
+        request
+    }
+
+    pub async fn refresh_from_env(&mut self, env: &EnvRef) -> StackResult<()> {
+        let req = match env.get("REQ").await {
+            Ok(Some(CollectionValue::Map(req))) => req,
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                return Err(stack_err!(
+                    StackErrorCode::ProcessChainError,
+                    "read REQ for stack handoff failed: {}",
+                    e
+                ));
+            }
+        };
+
+        macro_rules! refresh_string {
+            ($key:literal, $field:ident) => {
+                if let Some(CollectionValue::String(value)) = req.get($key).await.map_err(|e| {
+                    stack_err!(
+                        StackErrorCode::ProcessChainError,
+                        "read REQ.{} for stack handoff failed: {}",
+                        $key,
+                        e
+                    )
+                })? {
+                    self.$field = Some(value);
+                }
+            };
+        }
+
+        macro_rules! refresh_addr {
+            ($key:literal, $field:ident) => {
+                if let Some(CollectionValue::String(value)) = req.get($key).await.map_err(|e| {
+                    stack_err!(
+                        StackErrorCode::ProcessChainError,
+                        "read REQ.{} for stack handoff failed: {}",
+                        $key,
+                        e
+                    )
+                })? {
+                    self.$field = Some(value.parse().map_err(|e| {
+                        stack_err!(
+                            StackErrorCode::ProcessChainError,
+                            "invalid REQ.{} address {}: {}",
+                            $key,
+                            value,
+                            e
+                        )
+                    })?);
+                }
+            };
+        }
+
+        refresh_addr!("conn_source_addr", conn_source_addr);
+        refresh_addr!("source_addr", source_addr);
+        refresh_addr!("real_source_addr", real_source_addr);
+        refresh_addr!("dest_addr", dest_addr);
+        refresh_string!("dest_host", dest_host);
+        refresh_string!("app_protocol", app_protocol);
+        refresh_string!("dest_url", dest_url);
+        refresh_string!("source_mac", source_mac);
+        refresh_string!("source_hostname", source_hostname);
+        refresh_string!("source_device_id", source_device_id);
+        refresh_string!("source_app_id", source_app_id);
+        refresh_string!("source_user_id", source_user_id);
+        if let Some(CollectionValue::String(value)) = req.get("dest_port").await.map_err(|e| {
+            stack_err!(
+                StackErrorCode::ProcessChainError,
+                "read REQ.dest_port for stack handoff failed: {}",
+                e
+            )
+        })? {
+            self.dest_port = value.parse().map_err(|e| {
+                stack_err!(
+                    StackErrorCode::ProcessChainError,
+                    "invalid REQ.dest_port {}: {}",
+                    value,
+                    e
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    pub fn stream_info(&self, source_online_secs: Option<String>) -> StreamInfo {
+        StreamInfo::with_addrs(
+            self.conn_source_addr.map(|addr| addr.to_string()),
+            self.real_source_addr.map(|addr| addr.to_string()),
+        )
+        .with_dst_addr(self.dest_addr.map(|addr| addr.to_string()))
+        .with_device_info(
+            self.source_mac.clone(),
+            self.source_hostname.clone(),
+            source_online_secs,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+pub trait StreamStack: Stack {
+    async fn serve_stream(
+        &self,
+        stream: Box<dyn AsyncStream>,
+        context: StackStreamContext,
+    ) -> StackResult<()>;
+}
+
 #[async_trait::async_trait]
 pub trait Stack: Send + Sync + 'static {
     fn id(&self) -> String;
@@ -75,6 +248,10 @@ pub trait Stack: Send + Sync + 'static {
     ) -> StackResult<()>;
     async fn commit_update(&self);
     async fn rollback_update(&self);
+
+    fn as_stream_stack(&self) -> Option<&dyn StreamStack> {
+        None
+    }
 }
 
 pub type StackRef = Arc<dyn Stack>;
@@ -83,6 +260,7 @@ pub struct StackManager {
     stacks: Mutex<Vec<StackRef>>,
 }
 pub type StackManagerRef = Arc<StackManager>;
+pub type StackManagerWeakRef = Weak<StackManager>;
 
 impl StackManager {
     pub fn new() -> Arc<Self> {
@@ -121,6 +299,38 @@ impl StackManager {
             }
         }
         None
+    }
+
+    pub async fn serve_stream(
+        &self,
+        target_id: &str,
+        stream: Box<dyn AsyncStream>,
+        mut context: StackStreamContext,
+    ) -> StackResult<()> {
+        let target = self.get_stack(target_id).ok_or_else(|| {
+            stack_err!(
+                StackErrorCode::StackNotFound,
+                "stack handoff target {} not found",
+                target_id
+            )
+        })?;
+        if context.route.iter().any(|id| id == target_id) {
+            return Err(stack_err!(
+                StackErrorCode::StackHandoffCycle,
+                "stack handoff cycle detected: {} -> {}",
+                context.route.join(" -> "),
+                target_id
+            ));
+        }
+        let stream_stack = target.as_stream_stack().ok_or_else(|| {
+            stack_err!(
+                StackErrorCode::IncompatibleStack,
+                "stack handoff target {} does not accept ordered streams",
+                target_id
+            )
+        })?;
+        context.route.push(target_id.to_string());
+        stream_stack.serve_stream(stream, context).await
     }
 
     pub fn retain<F>(&self, f: F)

--- a/src/components/cyfs-gateway-lib/src/stack/tcp_stack.rs
+++ b/src/components/cyfs-gateway-lib/src/stack/tcp_stack.rs
@@ -1,6 +1,7 @@
 use super::{
-    Stack, get_limit_info, get_source_addr_from_req_env, probe_proxy_protocol_stream,
-    stream_forward, stream_forward_group,
+    Stack, StackManagerWeakRef, StackStreamContext, StreamStack, get_limit_info,
+    get_source_addr_from_req_env, probe_proxy_protocol_stream, stream_forward,
+    stream_forward_group,
 };
 use crate::forward::ForwardPlan;
 
@@ -17,8 +18,8 @@ use crate::{
     HandleConnectionController, IoDumpStackConfig, JsExternalsManagerRef, LimiterManagerRef,
     MutComposedSpeedStat, MutComposedSpeedStatRef, ProcessChainConfig, ProcessChainConfigs, Server,
     ServerManagerRef, StackConfig, StackContext, StackErrorCode, StackFactory, StackProtocol,
-    StackRef, StatManagerRef, StreamInfo, TunnelManager, create_io_dump_stack_config,
-    get_external_commands, get_stat_info, hyper_serve_http, into_stack_err, stack_err,
+    StackRef, StatManagerRef, TunnelManager, create_io_dump_stack_config, get_external_commands,
+    get_stat_info, hyper_serve_http, into_stack_err, stack_err,
 };
 use cyfs_process_chain::{CollectionValue, CommandControl, ProcessChainLibExecutor, StreamRequest};
 use serde::{Deserialize, Serialize};
@@ -41,6 +42,7 @@ pub struct TcpStackContext {
     pub global_process_chains: Option<GlobalProcessChainsRef>,
     pub global_collection_manager: Option<GlobalCollectionManagerRef>,
     pub js_externals: Option<JsExternalsManagerRef>,
+    pub stack_manager: StackManagerWeakRef,
 }
 
 impl TcpStackContext {
@@ -61,7 +63,13 @@ impl TcpStackContext {
             global_process_chains,
             global_collection_manager,
             js_externals,
+            stack_manager: StackManagerWeakRef::new(),
         }
+    }
+
+    pub fn with_stack_manager(mut self, stack_manager: StackManagerWeakRef) -> Self {
+        self.stack_manager = stack_manager;
+        self
     }
 }
 
@@ -72,6 +80,7 @@ impl StackContext for TcpStackContext {
 }
 
 struct TcpConnectionHandler {
+    stack_id: String,
     env: Arc<TcpStackContext>,
     executor: ProcessChainLibExecutor,
     connection_manager: Option<ConnectionManagerRef>,
@@ -80,6 +89,7 @@ struct TcpConnectionHandler {
 
 impl TcpConnectionHandler {
     async fn create(
+        stack_id: String,
         hook_point: ProcessChainConfigs,
         env: Arc<TcpStackContext>,
         connection_manager: Option<ConnectionManagerRef>,
@@ -95,6 +105,7 @@ impl TcpConnectionHandler {
         .await
         .map_err(into_stack_err!(StackErrorCode::ProcessChainError))?;
         Ok(Self {
+            stack_id,
             env,
             executor,
             connection_manager,
@@ -117,6 +128,7 @@ impl TcpConnectionHandler {
         .await
         .map_err(into_stack_err!(StackErrorCode::ProcessChainError))?;
         Ok(Self {
+            stack_id: self.stack_id.clone(),
             env: self.env.clone(),
             executor,
             connection_manager: self.connection_manager.clone(),
@@ -130,8 +142,6 @@ impl TcpConnectionHandler {
         dest_addr: SocketAddr,
         compose_stat: MutComposedSpeedStatRef,
     ) -> StackResult<()> {
-        let executor = self.executor.fork();
-        let servers = self.env.servers.clone();
         let remote_addr = stream.raw_stream().peer_addr().map_err(into_stack_err!(
             StackErrorCode::ServerError,
             "read remote addr failed"
@@ -164,30 +174,63 @@ impl TcpConnectionHandler {
             request.source_hostname = device_info.hostname().map(|v| v.to_string());
             request.source_online_secs = Some(device_info.today_online_seconds().to_string());
         }
+        let source_online_secs = request.source_online_secs.clone();
+        let context = StackStreamContext::from_request(self.stack_id.clone(), &request);
+        self.handle_stream(request, context, compose_stat, source_online_secs)
+            .await
+    }
+
+    async fn handle_handoff_stream(
+        &self,
+        stream: Box<dyn buckyos_kit::AsyncStream>,
+        context: StackStreamContext,
+    ) -> StackResult<()> {
+        let compose_stat = MutComposedSpeedStat::new();
+        let stream = StatStream::new_with_tracker(stream, compose_stat.clone());
+        let stream: Box<dyn buckyos_kit::AsyncStream> = if let Some(io_dump) = self.io_dump.clone()
+        {
+            Box::new(DumpStream::new(
+                stream,
+                io_dump,
+                context
+                    .conn_source_addr
+                    .or(context.source_addr)
+                    .map(|addr| addr.to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                context
+                    .dest_addr
+                    .map(|addr| addr.to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+            ))
+        } else {
+            Box::new(stream)
+        };
+        let request = context.create_request(stream);
+        self.handle_stream(request, context, compose_stat, None)
+            .await
+    }
+
+    async fn handle_stream(
+        &self,
+        request: StreamRequest,
+        mut context: StackStreamContext,
+        compose_stat: MutComposedSpeedStatRef,
+        source_online_secs: Option<String>,
+    ) -> StackResult<()> {
+        let executor = self.executor.fork();
+        let servers = self.env.servers.clone();
         let global_env = executor.global_env().clone();
         let (ret, stream) = execute_stream_chain(executor, request)
             .await
             .map_err(into_stack_err!(StackErrorCode::ProcessChainError))?;
-        let conn_src_addr = Some(remote_addr.to_string());
-        let mut real_src_addr = get_source_addr_from_req_env(&global_env)
+        context.refresh_from_env(&global_env).await?;
+        if let Some(real_source_addr) = get_source_addr_from_req_env(&global_env)
             .await
-            .and_then(|addr| addr.parse::<SocketAddr>().ok().map(|_| addr));
-        if real_src_addr.is_none() {
-            real_src_addr = proxy_source_addr.map(|addr| addr.to_string());
-        }
-        let mut stream_info = StreamInfo::with_addrs(conn_src_addr, real_src_addr)
-            .with_dst_addr(Some(dest_addr.to_string()));
-        if let Some(device_info) = self
-            .connection_manager
-            .as_ref()
-            .and_then(|manager| manager.get_device_info_by_source(device_lookup_ip))
+            .and_then(|addr| addr.parse::<SocketAddr>().ok())
         {
-            stream_info = stream_info.with_device_info(
-                device_info.mac().map(|v| v.to_string()),
-                device_info.hostname().map(|v| v.to_string()),
-                Some(device_info.today_online_seconds().to_string()),
-            );
+            context.real_source_addr = Some(real_source_addr);
         }
+        let stream_info = context.stream_info(source_online_secs);
         if ret.is_control() {
             if ret.is_drop() {
                 return Ok(());
@@ -344,6 +387,32 @@ impl TcpConnectionHandler {
                                 }
                             }
                         }
+                        "stack" => {
+                            if list.len() != 2 {
+                                return Err(stack_err!(
+                                    StackErrorCode::InvalidConfig,
+                                    "invalid stack command"
+                                ));
+                            }
+                            let stream = if limiter.is_some() {
+                                let (read_limit, write_limit) =
+                                    limiter.as_ref().unwrap().new_limit_session();
+                                Box::new(LimitStream::new(stream, read_limit, write_limit))
+                            } else {
+                                stream
+                            };
+                            let stack_manager =
+                                self.env.stack_manager.upgrade().ok_or_else(|| {
+                                    stack_err!(
+                                        StackErrorCode::StackNotFound,
+                                        "stack manager is unavailable for handoff from {}",
+                                        self.stack_id
+                                    )
+                                })?;
+                            stack_manager
+                                .serve_stream(list[1].as_str(), stream, context)
+                                .await?;
+                        }
                         v => {
                             log::error!("unknown command: {}", v);
                         }
@@ -440,6 +509,7 @@ impl TcpStack {
         let bind_addr = config.bind.unwrap();
         let env = config.stack_context.unwrap();
         let handler = TcpConnectionHandler::create(
+            id.clone(),
             config.hook_point.unwrap(),
             env,
             config.connection_manager.clone(),
@@ -682,6 +752,7 @@ impl Stack for TcpStack {
         .await
         .map_err(|e| stack_err!(StackErrorCode::InvalidConfig, "{e}"))?;
         let new_handler = TcpConnectionHandler::create(
+            self.id.clone(),
             config.hook_point.clone(),
             env,
             self.connection_manager.clone(),
@@ -701,6 +772,22 @@ impl Stack for TcpStack {
 
     async fn rollback_update(&self) {
         self.prepare_handler.write().unwrap().take();
+    }
+
+    fn as_stream_stack(&self) -> Option<&dyn StreamStack> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl StreamStack for TcpStack {
+    async fn serve_stream(
+        &self,
+        stream: Box<dyn buckyos_kit::AsyncStream>,
+        context: StackStreamContext,
+    ) -> StackResult<()> {
+        let handler = self.handler.read().unwrap().clone();
+        handler.handle_handoff_stream(stream, context).await
     }
 }
 
@@ -863,11 +950,12 @@ mod tests {
     use crate::{
         ConnectionManager, DefaultLimiterManager, GlobalCollectionManager, LimiterManagerRef,
         ProcessChainConfigs, Server, ServerManager, ServerManagerRef, ServerResult, Stack,
-        StackFactory, StackProtocol, StatManager, StatManagerRef, StreamInfo, StreamServer,
-        TcpStack, TcpStackConfig, TcpStackContext, TcpStackFactory, TunnelManager,
-        create_io_dump_stack_config, decode_io_dump_frames,
+        StackFactory, StackManager, StackProtocol, StackStreamContext, StatManager, StatManagerRef,
+        StreamInfo, StreamServer, StreamStack, TcpStack, TcpStackConfig, TcpStackContext,
+        TcpStackFactory, TunnelManager, create_io_dump_stack_config, decode_io_dump_frames,
     };
     use buckyos_kit::AsyncStream;
+    use cyfs_process_chain::StreamRequest;
     use std::path::Path;
     use std::sync::Arc;
     use std::time::Instant;
@@ -1245,6 +1333,105 @@ mod tests {
 
     pub struct MockServer {
         id: String,
+    }
+
+    #[tokio::test]
+    async fn test_stack_handoff_dv_tcp_to_tcp_without_listener() {
+        let target_chains: ProcessChainConfigs = serde_yaml_ng::from_str(
+            r#"
+- id: main
+  priority: 1
+  blocks:
+    - id: main
+      block: |
+        set-stat target-stat;
+        return "server handoff-target";
+"#,
+        )
+        .unwrap();
+        let source_chains: ProcessChainConfigs = serde_yaml_ng::from_str(
+            r#"
+- id: main
+  priority: 1
+  blocks:
+    - id: main
+      block: |
+        set-stat source-stat;
+        call-stack target;
+"#,
+        )
+        .unwrap();
+
+        let manager = StackManager::new();
+        let servers = Arc::new(ServerManager::new());
+        servers
+            .add_server(Server::Stream(Arc::new(MockServer::new(
+                "handoff-target".to_string(),
+            ))))
+            .unwrap();
+        let source_stat_manager = StatManager::new();
+        let target_stat_manager = StatManager::new();
+        let build_context = |stat_manager| {
+            Arc::new(
+                TcpStackContext::new(
+                    servers.clone(),
+                    TunnelManager::new(),
+                    Arc::new(DefaultLimiterManager::new()),
+                    stat_manager,
+                    Some(Arc::new(GlobalProcessChains::new())),
+                    None,
+                    None,
+                )
+                .with_stack_manager(Arc::downgrade(&manager)),
+            )
+        };
+        let source = Arc::new(
+            TcpStack::builder()
+                .id("source")
+                .bind("127.0.0.1:0")
+                .hook_point(source_chains)
+                .stack_context(build_context(source_stat_manager.clone()))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let target = Arc::new(
+            TcpStack::builder()
+                .id("target")
+                .bind("127.0.0.1:0")
+                .hook_point(target_chains)
+                .stack_context(build_context(target_stat_manager.clone()))
+                .build()
+                .await
+                .unwrap(),
+        );
+        manager.add_stack(source.clone()).unwrap();
+        manager.add_stack(target).unwrap();
+
+        let (mut client, handed_off) = tokio::io::duplex(64);
+        let (context_stream, _) = tokio::io::duplex(1);
+        let mut request =
+            StreamRequest::new(Box::new(context_stream), "192.0.2.10:443".parse().unwrap());
+        request.source_addr = Some("198.51.100.20:50000".parse().unwrap());
+        request.conn_source_addr = Some("198.51.100.20:50000".parse().unwrap());
+        let context = StackStreamContext::from_request("source", &request);
+
+        let serve = source.serve_stream(Box::new(handed_off), context);
+        let client_io = async move {
+            client.write_all(b"test").await.unwrap();
+            let mut response = [0u8; 4];
+            client.read_exact(&mut response).await.unwrap();
+            assert_eq!(&response, b"recv");
+        };
+        let (serve_result, ()) = tokio::join!(serve, client_io);
+        serve_result.unwrap();
+
+        let source_stat = source_stat_manager.get_speed_stat("source-stat").unwrap();
+        let target_stat = target_stat_manager.get_speed_stat("target-stat").unwrap();
+        assert_eq!(source_stat.get_read_sum_size(), 4);
+        assert_eq!(source_stat.get_write_sum_size(), 4);
+        assert_eq!(target_stat.get_read_sum_size(), 4);
+        assert_eq!(target_stat.get_write_sum_size(), 4);
     }
 
     impl MockServer {

--- a/src/components/cyfs-gateway-lib/src/stack/tls_stack.rs
+++ b/src/components/cyfs-gateway-lib/src/stack/tls_stack.rs
@@ -8,15 +8,16 @@ use crate::stack::tls_cert_resolver::{
     IdentityCertResolver, ResolvesServerCertUsingSni, TlsIdentityCertConfig, TlsIdentityHost,
 };
 use crate::stack::{
-    TlsCertResolver, get_limit_info, get_source_addr_from_req_env, probe_proxy_protocol_stream,
-    stream_forward, stream_forward_group,
+    StackManagerWeakRef, StackStreamContext, StreamStack, TlsCertResolver, get_limit_info,
+    get_source_addr_from_req_env, probe_proxy_protocol_stream, stream_forward,
+    stream_forward_group,
 };
 use crate::{
     ConnectionInfo, ConnectionManagerRef, DumpStream, GlobalCollectionManagerRef,
     HandleConnectionController, IoDumpStackConfig, JsExternalsManagerRef, LimiterManagerRef,
     MutComposedSpeedStat, MutComposedSpeedStatRef, ProcessChainConfigs, Server, ServerManagerRef,
     Stack, StackConfig, StackContext, StackErrorCode, StackProtocol, StackResult, StatManagerRef,
-    StreamInfo, TunnelManager, create_io_dump_stack_config, get_external_commands, get_stat_info,
+    TunnelManager, create_io_dump_stack_config, get_external_commands, get_stat_info,
     hyper_serve_http, into_stack_err, stack_err,
 };
 use cyfs_process_chain::{CollectionValue, CommandControl, ProcessChainLibExecutor, StreamRequest};
@@ -85,6 +86,7 @@ pub struct TlsStackContext {
     pub global_process_chains: Option<GlobalProcessChainsRef>,
     pub global_collection_manager: Option<GlobalCollectionManagerRef>,
     pub js_externals: Option<JsExternalsManagerRef>,
+    pub stack_manager: StackManagerWeakRef,
 }
 
 impl TlsStackContext {
@@ -107,7 +109,13 @@ impl TlsStackContext {
             global_process_chains,
             global_collection_manager,
             js_externals,
+            stack_manager: StackManagerWeakRef::new(),
         }
+    }
+
+    pub fn with_stack_manager(mut self, stack_manager: StackManagerWeakRef) -> Self {
+        self.stack_manager = stack_manager;
+        self
     }
 }
 
@@ -118,6 +126,7 @@ impl StackContext for TlsStackContext {
 }
 
 struct TlsConnectionHandler {
+    stack_id: String,
     env: Arc<TlsStackContext>,
     executor: ProcessChainLibExecutor,
     connection_manager: Option<ConnectionManagerRef>,
@@ -129,6 +138,7 @@ struct TlsConnectionHandler {
 
 impl TlsConnectionHandler {
     async fn create(
+        stack_id: String,
         hook_point: ProcessChainConfigs,
         certs: Vec<TlsDomainConfig>,
         identity_certs: Option<TlsIdentityCertConfig>,
@@ -149,6 +159,7 @@ impl TlsConnectionHandler {
         let certs = Self::build_cert_resolver(certs, identity_certs, env.as_ref())?;
         let server_config = Self::build_server_config(certs.clone(), &alpn_protocols)?;
         Ok(Self {
+            stack_id,
             env,
             executor,
             connection_manager,
@@ -170,6 +181,7 @@ impl TlsConnectionHandler {
         .await
         .map_err(into_stack_err!(StackErrorCode::ProcessChainError))?;
         Ok(Self {
+            stack_id: self.stack_id.clone(),
             env: self.env.clone(),
             executor,
             connection_manager: self.connection_manager.clone(),
@@ -257,60 +269,17 @@ impl TlsConnectionHandler {
         local_addr: SocketAddr,
         compose_stat: MutComposedSpeedStatRef,
     ) -> StackResult<()> {
-        let servers = self.env.servers.clone();
-        let executor = self.executor.fork();
         let remote_addr = stream.raw_stream().peer_addr().map_err(into_stack_err!(
             StackErrorCode::ServerError,
             "read remote addr failed"
         ))?;
         let (stream, proxy_source_addr) = probe_proxy_protocol_stream(Box::new(stream)).await?;
         let request_source_addr = proxy_source_addr.unwrap_or(remote_addr);
-
-        let tls_acceptor = TlsAcceptor::from(self.server_config.clone());
-        let tls_stream = tls_acceptor
-            .accept(stream)
-            .await
-            .map_err(into_stack_err!(StackErrorCode::StreamError))?;
-        let server_name = {
-            let (_, conn) = tls_stream.get_ref();
-            conn.server_name().map(|s| s.to_string())
-        };
-        if server_name.is_none() {
-            return Ok(());
-        }
-        if let Some(proxy_addr) = proxy_source_addr {
-            log::debug!(
-                "accept tls stream from {} (proxy via {}) to {} name {}",
-                proxy_addr,
-                remote_addr,
-                local_addr,
-                server_name.as_ref().unwrap_or(&"".to_string())
-            );
-        } else {
-            log::debug!(
-                "accept tls stream from {} to {} name {}",
-                remote_addr,
-                local_addr,
-                server_name.as_ref().unwrap_or(&"".to_string())
-            );
-        }
-        let request_stream: Box<dyn buckyos_kit::AsyncStream> =
-            if let Some(io_dump) = self.io_dump.clone() {
-                Box::new(DumpStream::new(
-                    tls_stream,
-                    io_dump,
-                    remote_addr.to_string(),
-                    local_addr.to_string(),
-                ))
-            } else {
-                Box::new(tls_stream)
-            };
-        let mut request = StreamRequest::new(request_stream, local_addr);
+        let mut request = StreamRequest::new(stream, local_addr);
         request.source_addr = Some(request_source_addr);
         request.conn_source_addr = Some(remote_addr);
         request.real_source_addr = proxy_source_addr;
         request.dest_port = local_addr.port();
-        request.dest_host = server_name;
         if let Some(device_info) = self
             .connection_manager
             .as_ref()
@@ -320,30 +289,100 @@ impl TlsConnectionHandler {
             request.source_hostname = device_info.hostname().map(|v| v.to_string());
             request.source_online_secs = Some(device_info.today_online_seconds().to_string());
         }
+        let source_online_secs = request.source_online_secs.clone();
+        let context = StackStreamContext::from_request(self.stack_id.clone(), &request);
+        let stream = request
+            .incoming_stream
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| {
+                stack_err!(
+                    StackErrorCode::StreamError,
+                    "listener stream is unavailable"
+                )
+            })?;
+        self.handle_tls_stream(stream, context, compose_stat, source_online_secs)
+            .await
+    }
+
+    async fn handle_tls_stream(
+        &self,
+        stream: Box<dyn buckyos_kit::AsyncStream>,
+        mut context: StackStreamContext,
+        compose_stat: MutComposedSpeedStatRef,
+        source_online_secs: Option<String>,
+    ) -> StackResult<()> {
+        let tls_acceptor = TlsAcceptor::from(self.server_config.clone());
+        let tls_stream = tls_acceptor
+            .accept(stream)
+            .await
+            .map_err(into_stack_err!(StackErrorCode::StreamError))?;
+        let server_name = {
+            let (_, conn) = tls_stream.get_ref();
+            conn.server_name().map(|s| s.to_string())
+        };
+        let Some(server_name) = server_name else {
+            return Ok(());
+        };
+        log::debug!(
+            "accept tls stream from {} to {} name {}",
+            context
+                .source_addr
+                .or(context.conn_source_addr)
+                .map(|addr| addr.to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            context
+                .dest_addr
+                .map(|addr| addr.to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            server_name
+        );
+        let request_stream: Box<dyn buckyos_kit::AsyncStream> =
+            if let Some(io_dump) = self.io_dump.clone() {
+                Box::new(DumpStream::new(
+                    tls_stream,
+                    io_dump,
+                    context
+                        .conn_source_addr
+                        .or(context.source_addr)
+                        .map(|addr| addr.to_string())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    context
+                        .dest_addr
+                        .map(|addr| addr.to_string())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ))
+            } else {
+                Box::new(tls_stream)
+            };
+        context.dest_host = Some(server_name);
+        let request = context.create_request(request_stream);
+        self.handle_stream(request, context, compose_stat, source_online_secs)
+            .await
+    }
+
+    async fn handle_stream(
+        &self,
+        request: StreamRequest,
+        mut context: StackStreamContext,
+        compose_stat: MutComposedSpeedStatRef,
+        source_online_secs: Option<String>,
+    ) -> StackResult<()> {
+        let servers = self.env.servers.clone();
+        let executor = self.executor.fork();
         let global_env = executor.global_env().clone();
         let (ret, stream) = execute_stream_chain(executor, request)
             .await
             .map_err(into_stack_err!(StackErrorCode::ProcessChainError))?;
-        let conn_src_addr = Some(remote_addr.to_string());
-        let mut real_src_addr = get_source_addr_from_req_env(&global_env)
+        context.refresh_from_env(&global_env).await?;
+        if let Some(real_source_addr) = get_source_addr_from_req_env(&global_env)
             .await
-            .and_then(|addr| addr.parse::<SocketAddr>().ok().map(|_| addr));
-        if real_src_addr.is_none() {
-            real_src_addr = proxy_source_addr.map(|addr| addr.to_string());
-        }
-        let mut stream_info = StreamInfo::with_addrs(conn_src_addr, real_src_addr)
-            .with_dst_addr(Some(local_addr.to_string()));
-        if let Some(device_info) = self
-            .connection_manager
-            .as_ref()
-            .and_then(|manager| manager.get_device_info_by_source(request_source_addr.ip()))
+            .and_then(|addr| addr.parse::<SocketAddr>().ok())
         {
-            stream_info = stream_info.with_device_info(
-                device_info.mac().map(|v| v.to_string()),
-                device_info.hostname().map(|v| v.to_string()),
-                Some(device_info.today_online_seconds().to_string()),
-            );
+            context.real_source_addr = Some(real_source_addr);
         }
+        let stream_info = context.stream_info(source_online_secs);
         if ret.is_control() {
             if ret.is_drop() {
                 return Ok(());
@@ -502,6 +541,32 @@ impl TlsConnectionHandler {
                                 }
                             }
                         }
+                        "stack" => {
+                            if list.len() != 2 {
+                                return Err(stack_err!(
+                                    StackErrorCode::InvalidConfig,
+                                    "invalid stack command"
+                                ));
+                            }
+                            let stream = if limiter.is_some() {
+                                let (read_limit, write_limit) =
+                                    limiter.as_ref().unwrap().new_limit_session();
+                                Box::new(LimitStream::new(stream, read_limit, write_limit))
+                            } else {
+                                stream
+                            };
+                            let stack_manager =
+                                self.env.stack_manager.upgrade().ok_or_else(|| {
+                                    stack_err!(
+                                        StackErrorCode::StackNotFound,
+                                        "stack manager is unavailable for handoff from {}",
+                                        self.stack_id
+                                    )
+                                })?;
+                            stack_manager
+                                .serve_stream(list[1].as_str(), stream, context)
+                                .await?;
+                        }
                         v => {
                             log::error!("unknown command: {}", v);
                         }
@@ -563,6 +628,7 @@ impl TlsStack {
         let bind_addr = config.bind.unwrap();
         let env = config.stack_context.unwrap();
         let handler = TlsConnectionHandler::create(
+            id.clone(),
             config.hook_point.unwrap(),
             config.certs,
             config.identity_certs,
@@ -762,6 +828,7 @@ impl Stack for TlsStack {
         let cert_list = build_tls_domain_configs(config).await?;
 
         let new_handler = TlsConnectionHandler::create(
+            self.id.clone(),
             config.hook_point.clone(),
             cert_list,
             build_tls_identity_cert_config(&config.hosts, config.identity_manager.as_ref())?,
@@ -793,6 +860,26 @@ impl Stack for TlsStack {
 
     async fn rollback_update(&self) {
         self.prepare_handler.write().unwrap().take();
+    }
+
+    fn as_stream_stack(&self) -> Option<&dyn StreamStack> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl StreamStack for TlsStack {
+    async fn serve_stream(
+        &self,
+        stream: Box<dyn buckyos_kit::AsyncStream>,
+        context: StackStreamContext,
+    ) -> StackResult<()> {
+        let handler = self.handler.read().unwrap().clone();
+        let compose_stat = MutComposedSpeedStat::new();
+        let stream = StatStream::new_with_tracker(stream, compose_stat.clone());
+        handler
+            .handle_tls_stream(Box::new(stream), context, compose_stat, None)
+            .await
     }
 }
 
@@ -1186,14 +1273,16 @@ mod tests {
     use crate::{
         ConnectionManager, DefaultLimiterManager, GlobalCollectionManager, MutComposedSpeedStat,
         ProcessChainConfigs, ProcessChainHttpServer, Server, ServerManager, ServerResult, Stack,
-        StackFactory, StackProtocol, StatManager, StreamInfo, StreamServer, TlsStackConfig,
-        TlsStackFactory, TunnelManager, create_io_dump_stack_config, decode_io_dump_frames,
+        StackFactory, StackManager, StackProtocol, StackStreamContext, StatManager, StreamInfo,
+        StreamServer, StreamStack, TcpStack, TcpStackContext, TlsStackConfig, TlsStackFactory,
+        TunnelManager, create_io_dump_stack_config, decode_io_dump_frames,
     };
     use crate::{
         LimiterManagerRef, ServerManagerRef, StackContext, StatManagerRef, TlsDomainConfig,
         TlsStack, TlsStackContext,
     };
     use buckyos_kit::{AsyncStream, init_logging};
+    use cyfs_process_chain::StreamRequest;
     use http_body_util::Full;
     use hyper::body::Bytes;
     use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -1895,6 +1984,7 @@ mod tests {
             Some(Arc::new(GlobalProcessChains::new())),
         );
         let mut handler = TlsConnectionHandler::create(
+            "test-tls".to_string(),
             chains,
             vec![TlsDomainConfig {
                 domain: "www.buckyos.com".to_string(),
@@ -2042,6 +2132,207 @@ mod tests {
         let ret = stream.read_exact(&mut buf).await;
         assert!(ret.is_ok());
         assert_eq!(&buf, b"recv");
+    }
+
+    #[tokio::test]
+    async fn test_stack_handoff_dv_tls_accepts_existing_stream() {
+        let cert_key = generate_simple_self_signed(vec!["www.buckyos.com".to_string()]).unwrap();
+        let chains: ProcessChainConfigs = serde_yaml_ng::from_str(
+            r#"
+- id: main
+  priority: 1
+  blocks:
+    - id: main
+      block: |
+        return "server handoff-tls";
+"#,
+        )
+        .unwrap();
+        let server_manager = Arc::new(ServerManager::new());
+        server_manager
+            .add_server(Server::Stream(Arc::new(MockServer::new(
+                "handoff-tls".to_string(),
+            ))))
+            .unwrap();
+        let stack = TlsStack::builder()
+            .id("target-tls")
+            .bind("127.0.0.1:0")
+            .hook_point(chains)
+            .add_certs(vec![TlsDomainConfig {
+                domain: "www.buckyos.com".to_string(),
+                certs: Some(vec![cert_key.cert.der().clone()]),
+                key: Some(PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+                    cert_key.signing_key.serialize_der(),
+                ))),
+            }])
+            .alpn_protocols(vec![b"http/1.1".to_vec()])
+            .stack_context(build_stack_context(
+                server_manager,
+                TunnelManager::new(),
+                Arc::new(DefaultLimiterManager::new()),
+                StatManager::new(),
+                SelfCertMgr::create(SelfCertConfig::default())
+                    .await
+                    .unwrap(),
+                Some(Arc::new(GlobalProcessChains::new())),
+            ))
+            .build()
+            .await
+            .unwrap();
+
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let (context_stream, _) = tokio::io::duplex(1);
+        let mut request =
+            StreamRequest::new(Box::new(context_stream), "192.0.2.10:443".parse().unwrap());
+        request.source_addr = Some("198.51.100.20:50000".parse().unwrap());
+        request.conn_source_addr = Some("198.51.100.20:50000".parse().unwrap());
+        let context = StackStreamContext::from_request("source-tcp", &request);
+        let serve = stack.serve_stream(Box::new(server_io), context);
+        let client = async move {
+            let config = ClientConfig::builder_with_provider(Arc::new(
+                rustls::crypto::ring::default_provider(),
+            ))
+            .with_protocol_versions(rustls::DEFAULT_VERSIONS)
+            .unwrap()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerifier))
+            .with_no_client_auth();
+            let connector = TlsConnector::from(Arc::new(config));
+            let mut stream = connector
+                .connect(ServerName::try_from("www.buckyos.com").unwrap(), client_io)
+                .await
+                .unwrap();
+            stream.write_all(b"test").await.unwrap();
+            let mut response = [0u8; 4];
+            stream.read_exact(&mut response).await.unwrap();
+            assert_eq!(&response, b"recv");
+        };
+        let (serve_result, ()) = tokio::join!(serve, client);
+        serve_result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stack_handoff_dv_tcp_sni_probe_to_tls() {
+        let cert_key = generate_simple_self_signed(vec!["www.buckyos.com".to_string()]).unwrap();
+        let source_chains: ProcessChainConfigs = serde_yaml_ng::from_str(
+            r#"
+- id: main
+  priority: 1
+  blocks:
+    - id: main
+      block: |
+        call https-sni-probe || reject;
+        eq ${REQ.dest_host} "www.buckyos.com" && call-stack target-tls;
+        reject;
+"#,
+        )
+        .unwrap();
+        let target_chains: ProcessChainConfigs = serde_yaml_ng::from_str(
+            r#"
+- id: main
+  priority: 1
+  blocks:
+    - id: main
+      block: |
+        return "server handoff-tls";
+"#,
+        )
+        .unwrap();
+        let manager = StackManager::new();
+        let servers = Arc::new(ServerManager::new());
+        servers
+            .add_server(Server::Stream(Arc::new(MockServer::new(
+                "handoff-tls".to_string(),
+            ))))
+            .unwrap();
+        let source_context = Arc::new(
+            TcpStackContext::new(
+                servers.clone(),
+                TunnelManager::new(),
+                Arc::new(DefaultLimiterManager::new()),
+                StatManager::new(),
+                Some(Arc::new(GlobalProcessChains::new())),
+                None,
+                None,
+            )
+            .with_stack_manager(Arc::downgrade(&manager)),
+        );
+        let tls_context = build_stack_context(
+            servers,
+            TunnelManager::new(),
+            Arc::new(DefaultLimiterManager::new()),
+            StatManager::new(),
+            SelfCertMgr::create(SelfCertConfig::default())
+                .await
+                .unwrap(),
+            Some(Arc::new(GlobalProcessChains::new())),
+        );
+        let tls_context = Arc::new(
+            tls_context
+                .as_ref()
+                .clone()
+                .with_stack_manager(Arc::downgrade(&manager)),
+        );
+        let source = Arc::new(
+            TcpStack::builder()
+                .id("source-tcp")
+                .bind("127.0.0.1:0")
+                .hook_point(source_chains)
+                .stack_context(source_context)
+                .build()
+                .await
+                .unwrap(),
+        );
+        let target = Arc::new(
+            TlsStack::builder()
+                .id("target-tls")
+                .bind("127.0.0.1:0")
+                .hook_point(target_chains)
+                .add_certs(vec![TlsDomainConfig {
+                    domain: "www.buckyos.com".to_string(),
+                    certs: Some(vec![cert_key.cert.der().clone()]),
+                    key: Some(PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+                        cert_key.signing_key.serialize_der(),
+                    ))),
+                }])
+                .alpn_protocols(vec![b"http/1.1".to_vec()])
+                .stack_context(tls_context)
+                .build()
+                .await
+                .unwrap(),
+        );
+        manager.add_stack(source.clone()).unwrap();
+        manager.add_stack(target).unwrap();
+
+        let (client_io, source_io) = tokio::io::duplex(4096);
+        let (context_stream, _) = tokio::io::duplex(1);
+        let mut request =
+            StreamRequest::new(Box::new(context_stream), "192.0.2.10:443".parse().unwrap());
+        request.source_addr = Some("198.51.100.20:50000".parse().unwrap());
+        request.conn_source_addr = Some("198.51.100.20:50000".parse().unwrap());
+        let context = StackStreamContext::from_request("source-tcp", &request);
+        let serve = source.serve_stream(Box::new(source_io), context);
+        let client = async move {
+            let config = ClientConfig::builder_with_provider(Arc::new(
+                rustls::crypto::ring::default_provider(),
+            ))
+            .with_protocol_versions(rustls::DEFAULT_VERSIONS)
+            .unwrap()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerifier))
+            .with_no_client_auth();
+            let connector = TlsConnector::from(Arc::new(config));
+            let mut stream = connector
+                .connect(ServerName::try_from("www.buckyos.com").unwrap(), client_io)
+                .await
+                .unwrap();
+            stream.write_all(b"test").await.unwrap();
+            let mut response = [0u8; 4];
+            stream.read_exact(&mut response).await.unwrap();
+            assert_eq!(&response, b"recv");
+        };
+        let (serve_result, ()) = tokio::join!(serve, client);
+        serve_result.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
  ## 基本信息

  - Base: `beta2.2`
  - Head: `call_stack`
  - 变更提交: `455b4fe feat(stack): add cross-stack stream handoff`
  - Change ID: `CHG-in-process-stream-stack-handoff`

  ## 背景

  当前同一 Gateway 进程内的 Stack 间转发仍需建立新的回环 TCP 连接，并通过双向复制中继数据。

  本 PR 新增 `call-stack <stack_id>` process-chain 命令，使已接收的有序字节流可以直接移交给同一进程内支持该能力的目标 Stack，避免额外的 connect、accept 和 `copy_bidirectional`。

  ## 变更摘要

  - 新增 `call-stack <stack_id>` 外部命令，返回内部终止动作 `stack <stack_id>`。
  - 新增 `StreamStack` 能力接口和 `StackStreamContext`，用于转交 stream 及其请求上下文。
  - `TcpStack` 和 `TlsStack` 支持作为 handoff 源或目标。
  - `StackManager` 在执行时动态解析目标 Stack，兼容 Stack 热更新和重新装载。
  - TCP/TLS Stack 通过弱引用访问 `StackManager`，避免运行时所有权环。
  - 转交过程中保留：
    - 原始连接、来源及目标地址；
    - `dest_host`、`dest_port`、应用协议和 URL；
    - device、app、user 等来源身份字段；
    - `https-sni-probe` 已缓存的 ClientHello 数据。
  - process chain 修改 `REQ` 后，会在 handoff 前刷新可路由字段。
  - 来源 Stack 和目标 Stack 保持各自独立的流量统计与 limiter 包装，不转移或合并统计 tracker。
  - 一个物理连接仍只创建一条 `ConnectionManager` 记录；目标 Stack 不重复执行 listener accept 或 PROXY protocol 预处理。
  - 对以下情况增加确定性的 fail-closed 错误：
    - 目标 Stack 不存在；
    - 目标不支持有序流；
    - Stack 自调用；
    - 重复或循环 handoff。
  - 同步接入 `cyfs_gateway` 和 `web3_gateway` 的初始化及热更新组装路径。

  ## 使用示例

  ```text
  https-sni-probe
      && eq ${REQ.dest_host} "www.example.com"
      && call-stack main_tls;
  ```
  该路径会将当前 stream 直接交给 main_tls，目标 TLS Stack 继续执行正常的 TLS 握手、hook point 和 server dispatch。

  ## 兼容性与范围

  - call-stack 为 opt-in 行为，现有配置不会自动改变。
  - forward、forward-group 和 call-server 的现有动作保持不变。
  - 当前仅 TCP/TLS Stack 暴露有序流能力。
  - RTCP、QUIC、UDP 和 TUN Stack 不在本次实现范围内。
  - 本 PR 不修改生产 web3_gateway.yaml 路由。
  - source_online_secs 属于 listener 本地观测信息，不在 Stack 间传递。
  - 未增加新的运行时依赖。

  ## 测试覆盖

  新增或扩展了以下覆盖：

  - call-stack 参数校验与命令注册；
  - TCP → TCP 直接 stream handoff；
  - TCP SNI probe → TLS handoff；
  - TLS → TCP handoff；
  - 已建立 stream 上的 TLS accept；
  - ClientHello 缓冲数据和请求元数据保留；
  - Gateway 配置装载与三条端到端 handoff 路径。

  ## 验证结果

  - [x] git diff --check beta2.2...HEAD
  - [x] cargo test -p cyfs-gateway-lib call_stack -- --test-threads=1
      - 2 passed，0 failed

  - [x] cargo test -p cyfs-gateway-lib stack_handoff -- --test-threads=1
      - 3 passed，0 failed

  - [x] cargo test -p cyfs_gateway --test test_cyfs_gateway test_cyfs_gateway -- --test-threads=1
      - 1 passed，0 failed
      - 覆盖 TCP→TCP、TCP→TLS、TLS→TCP

  测试期间仍会报告 udp_stack.rs 中两个既有的 unused_unsafe warning，本 PR 未修改该文件。

  ## Review 重点

  - 确认 handoff 后 stream 只有目标 Stack 持有，来源 Stack 不再访问。
  - 确认 listener 专属的 PROXY protocol 和连接登记不会在目标 Stack 重复执行。
  - 确认 https-sni-probe 缓冲的 ClientHello 字节完整进入目标 TLS acceptor。
  - 确认来源与目标 Stack 的统计 tracker 相互独立。
  - 确认未知、不兼容及循环目标均关闭连接并返回确定性错误。
  - 确认弱引用的 StackManager 组装同时覆盖初始启动和配置热更新路径。

  ## 回滚方案

  回退提交 455b4fe 即可恢复原有 Stack 行为。现有网络 forward 路径未被移除，可继续作为配置级回滚方案。
