### PR TITLE
feat(sn): route PostgreSQL user DNS through auth provider

### DIFF
--- a/src/components/cyfs-sn/src/s2s_api/sn_auth_db.rs
+++ b/src/components/cyfs-sn/src/s2s_api/sn_auth_db.rs
@@ -35,6 +35,10 @@ pub const METHOD_GET_AUTH: &str = "sn_auth_db.get_auth";
 pub const METHOD_UPDATE_LAST_LOGIN: &str = "sn_auth_db.update_last_login";
 pub const METHOD_ACTIVATE_USER_DOMAIN_BINDING: &str = "sn_auth_db.activate_user_domain_binding";
 pub const METHOD_UNBIND_USER_DOMAIN: &str = "sn_auth_db.unbind_user_domain";
+pub const METHOD_ADD_USER_DNS_RECORD: &str = "sn_auth_db.add_user_dns_record";
+pub const METHOD_REMOVE_USER_DNS_RECORD: &str = "sn_auth_db.remove_user_dns_record";
+pub const METHOD_QUERY_USER_DNS_RECORD: &str = "sn_auth_db.query_user_dns_record";
+pub const METHOD_LIST_USER_DNS_RECORDS: &str = "sn_auth_db.list_user_dns_records";
 pub const METHOD_GET_ZONE_INFO: &str = "sn_auth_db.get_zone_info";
 pub const METHOD_UPDATE_ZONE_INFO: &str = "sn_auth_db.update_zone_info";
 pub const METHOD_UPDATE_ZONE_RELAY_SN: &str = "sn_auth_db.update_zone_relay_sn";
@@ -517,6 +521,67 @@ impl SnAuthDbUnbindUserDomainReq {
     }
 
     impl_req_from_json!(SnAuthDbUnbindUserDomainReq);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnAuthDbAddUserDnsRecordReq {
+    pub username: String,
+    pub domain: String,
+    pub record_type: String,
+    pub record: String,
+    pub ttl: u32,
+}
+
+impl SnAuthDbAddUserDnsRecordReq {
+    pub fn new(username: &str, domain: &str, record_type: &str, record: &str, ttl: u32) -> Self {
+        Self {
+            username: username.to_string(),
+            domain: domain.to_string(),
+            record_type: record_type.to_string(),
+            record: record.to_string(),
+            ttl,
+        }
+    }
+
+    impl_req_from_json!(SnAuthDbAddUserDnsRecordReq);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnAuthDbRemoveUserDnsRecordReq {
+    pub username: String,
+    pub domain: String,
+    pub record_type: String,
+    pub record: Option<String>,
+}
+
+impl SnAuthDbRemoveUserDnsRecordReq {
+    pub fn new(username: &str, domain: &str, record_type: &str, record: Option<&str>) -> Self {
+        Self {
+            username: username.to_string(),
+            domain: domain.to_string(),
+            record_type: record_type.to_string(),
+            record: record.map(ToString::to_string),
+        }
+    }
+
+    impl_req_from_json!(SnAuthDbRemoveUserDnsRecordReq);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnAuthDbQueryUserDnsRecordReq {
+    pub domain: String,
+    pub record_type: String,
+}
+
+impl SnAuthDbQueryUserDnsRecordReq {
+    pub fn new(domain: &str, record_type: &str) -> Self {
+        Self {
+            domain: domain.to_string(),
+            record_type: record_type.to_string(),
+        }
+    }
+
+    impl_req_from_json!(SnAuthDbQueryUserDnsRecordReq);
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1066,6 +1131,86 @@ impl SnAuthDB for SnAuthDbClient {
         }
     }
 
+    async fn add_user_dns_record(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: &str,
+        ttl: u32,
+    ) -> SnResult<()> {
+        match self {
+            Self::InProcess(handler) => {
+                handler
+                    .add_user_dns_record(username, domain, record_type, record, ttl)
+                    .await
+            }
+            Self::KRPC(_) => {
+                self.call(
+                    METHOD_ADD_USER_DNS_RECORD,
+                    &SnAuthDbAddUserDnsRecordReq::new(username, domain, record_type, record, ttl),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn remove_user_dns_record(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: Option<&str>,
+    ) -> SnResult<()> {
+        match self {
+            Self::InProcess(handler) => {
+                handler
+                    .remove_user_dns_record(username, domain, record_type, record)
+                    .await
+            }
+            Self::KRPC(_) => {
+                self.call(
+                    METHOD_REMOVE_USER_DNS_RECORD,
+                    &SnAuthDbRemoveUserDnsRecordReq::new(username, domain, record_type, record),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn query_user_dns_record(
+        &self,
+        domain: &str,
+        record_type: &str,
+    ) -> SnResult<Option<(String, u32)>> {
+        match self {
+            Self::InProcess(handler) => handler.query_user_dns_record(domain, record_type).await,
+            Self::KRPC(_) => {
+                self.call(
+                    METHOD_QUERY_USER_DNS_RECORD,
+                    &SnAuthDbQueryUserDnsRecordReq::new(domain, record_type),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn list_user_dns_records(
+        &self,
+        username: &str,
+    ) -> SnResult<Vec<(String, String, String, u32)>> {
+        match self {
+            Self::InProcess(handler) => handler.list_user_dns_records(username).await,
+            Self::KRPC(_) => {
+                self.call(
+                    METHOD_LIST_USER_DNS_RECORDS,
+                    &SnAuthDbUsernameReq::new(username),
+                )
+                .await
+            }
+        }
+    }
+
     async fn get_zone_info(&self, username: &str) -> SnResult<Option<ZoneInfo>> {
         match self {
             Self::InProcess(handler) => handler.get_zone_info(username).await,
@@ -1372,6 +1517,48 @@ where
                         .await,
                     &req,
                 )
+            }
+            METHOD_ADD_USER_DNS_RECORD | "add_user_dns_record" => {
+                let parsed = SnAuthDbAddUserDnsRecordReq::from_json(req.params.clone())?;
+                rpc_envelope_response(
+                    self.0
+                        .add_user_dns_record(
+                            &parsed.username,
+                            &parsed.domain,
+                            &parsed.record_type,
+                            &parsed.record,
+                            parsed.ttl,
+                        )
+                        .await,
+                    &req,
+                )
+            }
+            METHOD_REMOVE_USER_DNS_RECORD | "remove_user_dns_record" => {
+                let parsed = SnAuthDbRemoveUserDnsRecordReq::from_json(req.params.clone())?;
+                rpc_envelope_response(
+                    self.0
+                        .remove_user_dns_record(
+                            &parsed.username,
+                            &parsed.domain,
+                            &parsed.record_type,
+                            parsed.record.as_deref(),
+                        )
+                        .await,
+                    &req,
+                )
+            }
+            METHOD_QUERY_USER_DNS_RECORD | "query_user_dns_record" => {
+                let parsed = SnAuthDbQueryUserDnsRecordReq::from_json(req.params.clone())?;
+                rpc_envelope_response(
+                    self.0
+                        .query_user_dns_record(&parsed.domain, &parsed.record_type)
+                        .await,
+                    &req,
+                )
+            }
+            METHOD_LIST_USER_DNS_RECORDS | "list_user_dns_records" => {
+                let parsed = SnAuthDbUsernameReq::from_json(req.params.clone())?;
+                rpc_envelope_response(self.0.list_user_dns_records(&parsed.username).await, &req)
             }
             METHOD_GET_ZONE_INFO | "get_zone_info" => {
                 let parsed = SnAuthDbUsernameReq::from_json(req.params.clone())?;

--- a/src/components/cyfs-sn/src/sn_auth.rs
+++ b/src/components/cyfs-sn/src/sn_auth.rs
@@ -400,6 +400,58 @@ pub trait SnAuthDB: Send + Sync + 'static {
     ) -> SnResult<DomainBinding>;
     async fn unbind_user_domain(&self, username: &str, domain: &str) -> SnResult<()>;
 
+    /// Compatibility DNS RRsets are part of the shared auth/provider state in
+    /// postgres mode. SQLite deployments continue to use the local
+    /// `SnCompatibilityStore` implementation.
+    async fn add_user_dns_record(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: &str,
+        ttl: u32,
+    ) -> SnResult<()> {
+        let _ = (username, domain, record_type, record, ttl);
+        Err(sn_err!(
+            SnErrorCode::Failed,
+            "user DNS records are not supported by this auth DB"
+        ))
+    }
+    async fn remove_user_dns_record(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: Option<&str>,
+    ) -> SnResult<()> {
+        let _ = (username, domain, record_type, record);
+        Err(sn_err!(
+            SnErrorCode::Failed,
+            "user DNS records are not supported by this auth DB"
+        ))
+    }
+    async fn query_user_dns_record(
+        &self,
+        domain: &str,
+        record_type: &str,
+    ) -> SnResult<Option<(String, u32)>> {
+        let _ = (domain, record_type);
+        Err(sn_err!(
+            SnErrorCode::Failed,
+            "user DNS records are not supported by this auth DB"
+        ))
+    }
+    async fn list_user_dns_records(
+        &self,
+        username: &str,
+    ) -> SnResult<Vec<(String, String, String, u32)>> {
+        let _ = username;
+        Err(sn_err!(
+            SnErrorCode::Failed,
+            "user DNS records are not supported by this auth DB"
+        ))
+    }
+
     async fn get_zone_info(&self, username: &str) -> SnResult<Option<ZoneInfo>>;
     async fn update_zone_info(&self, username: &str, patch: ZoneInfoPatch) -> SnResult<()>;
     async fn update_zone_relay_sn(
@@ -606,6 +658,46 @@ impl SnAuthDB for RemoteSnAuthDB {
 
     async fn unbind_user_domain(&self, username: &str, domain: &str) -> SnResult<()> {
         self.client.unbind_user_domain(username, domain).await
+    }
+
+    async fn add_user_dns_record(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: &str,
+        ttl: u32,
+    ) -> SnResult<()> {
+        self.client
+            .add_user_dns_record(username, domain, record_type, record, ttl)
+            .await
+    }
+
+    async fn remove_user_dns_record(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: Option<&str>,
+    ) -> SnResult<()> {
+        self.client
+            .remove_user_dns_record(username, domain, record_type, record)
+            .await
+    }
+
+    async fn query_user_dns_record(
+        &self,
+        domain: &str,
+        record_type: &str,
+    ) -> SnResult<Option<(String, u32)>> {
+        self.client.query_user_dns_record(domain, record_type).await
+    }
+
+    async fn list_user_dns_records(
+        &self,
+        username: &str,
+    ) -> SnResult<Vec<(String, String, String, u32)>> {
+        self.client.list_user_dns_records(username).await
     }
 
     async fn get_zone_info(&self, username: &str) -> SnResult<Option<ZoneInfo>> {

--- a/src/components/cyfs-sn/src/sn_compat_store.rs
+++ b/src/components/cyfs-sn/src/sn_compat_store.rs
@@ -1,4 +1,4 @@
-use crate::{SnErrorCode, SnResult, into_sn_err};
+use crate::{into_sn_err, SnAuthDBRef, SnErrorCode, SnResult};
 use serde::{Deserialize, Serialize};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteRow};
 use sqlx::{Row, SqlitePool};
@@ -109,6 +109,88 @@ pub trait SnCompatibilityStore: Send + Sync + 'static {
         obj_name: &str,
         doc_type: Option<&str>,
     ) -> SnResult<Option<(String, String, Option<String>)>>;
+}
+
+/// Keeps legacy device/DID compatibility reads local while routing mutable DNS
+/// RRsets through the shared auth provider. This is used only for remote
+/// database modes; SQLite keeps using `SqliteSnCompatibilityStore` directly.
+pub struct AuthDbRoutedSnCompatibilityStore {
+    auth_db: SnAuthDBRef,
+    local: SnCompatibilityStoreRef,
+}
+
+impl AuthDbRoutedSnCompatibilityStore {
+    pub fn new(auth_db: SnAuthDBRef, local: SnCompatibilityStoreRef) -> Self {
+        Self { auth_db, local }
+    }
+}
+
+#[async_trait::async_trait]
+impl SnCompatibilityStore for AuthDbRoutedSnCompatibilityStore {
+    async fn query_device_by_name(
+        &self,
+        username: &str,
+        device_name: &str,
+    ) -> SnResult<Option<SNDeviceInfo>> {
+        self.local.query_device_by_name(username, device_name).await
+    }
+
+    async fn query_device_by_did(&self, did: &str) -> SnResult<Option<SNDeviceInfo>> {
+        self.local.query_device_by_did(did).await
+    }
+
+    async fn add_user_domain(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: &str,
+        ttl: u32,
+    ) -> SnResult<()> {
+        self.auth_db
+            .add_user_dns_record(username, domain, record_type, record, ttl)
+            .await
+    }
+
+    async fn remove_user_domain(
+        &self,
+        username: &str,
+        domain: &str,
+        record_type: &str,
+        record: Option<&str>,
+    ) -> SnResult<()> {
+        self.auth_db
+            .remove_user_dns_record(username, domain, record_type, record)
+            .await
+    }
+
+    async fn query_domain_record(
+        &self,
+        domain: &str,
+        record_type: &str,
+    ) -> SnResult<Option<(String, u32)>> {
+        self.auth_db
+            .query_user_dns_record(domain, record_type)
+            .await
+    }
+
+    async fn query_user_domain_records(
+        &self,
+        username: &str,
+    ) -> SnResult<Vec<(String, String, String, u32)>> {
+        self.auth_db.list_user_dns_records(username).await
+    }
+
+    async fn query_user_did_document(
+        &self,
+        owner_user: &str,
+        obj_name: &str,
+        doc_type: Option<&str>,
+    ) -> SnResult<Option<(String, String, Option<String>)>> {
+        self.local
+            .query_user_did_document(owner_user, obj_name, doc_type)
+            .await
+    }
 }
 
 pub struct SqliteSnCompatibilityStore {

--- a/src/components/cyfs-sn/src/sn_resolver.rs
+++ b/src/components/cyfs-sn/src/sn_resolver.rs
@@ -2867,22 +2867,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn absent_underscore_txt_record_does_not_fall_through_to_bns() {
-        let resolver = test_resolver_with_bns(StaticBnsReader::default());
-
-        for hostname in [
-            "_acme-challenge.alice.web3.buckyos.test",
-            "_pkx.alice.web3.buckyos.test",
-        ] {
-            let error = resolver
-                .resolve_dns(hostname, RecordType::TXT)
-                .await
-                .unwrap_err();
-            assert_eq!(error.kind(), SnResolverErrorKind::DocumentNotFound);
-        }
-    }
-
     #[test]
     fn dns_address_filter_removes_loopback_and_docker_bridge() {
         let mut addresses = Vec::new();

--- a/src/components/cyfs-sn/src/sn_resolver.rs
+++ b/src/components/cyfs-sn/src/sn_resolver.rs
@@ -961,6 +961,16 @@ impl SnResolver {
             return explicit_dns_record(hostname.as_str(), record_type, record.as_str(), ttl);
         }
 
+        // Underscore-prefixed TXT names are control records such as ACME and
+        // PKX. They only exist when explicitly stored; falling through would
+        // either expose the zone's root TXT data or send an invalid BNS name.
+        if is_explicit_only_dns_name(hostname.as_str(), record_type) {
+            return Err(SnResolverError::new(
+                SnResolverErrorKind::DocumentNotFound,
+                format!("explicit TXT record not found for {}", hostname),
+            ));
+        }
+
         let zone = self.resolve_zone_by_hostname(hostname.as_str()).await?;
 
         if record_type == RecordType::TXT {
@@ -1995,6 +2005,11 @@ fn is_supported_record_type(record_type: RecordType) -> bool {
     )
 }
 
+fn is_explicit_only_dns_name(hostname: &str, record_type: RecordType) -> bool {
+    record_type == RecordType::TXT
+        && matches!(hostname.split('.').next(), Some(label) if label.starts_with('_'))
+}
+
 fn normalize_host_lossy(hostname: &str) -> String {
     hostname.trim().trim_end_matches('.').to_ascii_lowercase()
 }
@@ -2850,6 +2865,22 @@ mod tests {
             bns_compat_name_for("devtests.org", "alice.web3.other.org"),
             None
         );
+    }
+
+    #[tokio::test]
+    async fn absent_underscore_txt_record_does_not_fall_through_to_bns() {
+        let resolver = test_resolver_with_bns(StaticBnsReader::default());
+
+        for hostname in [
+            "_acme-challenge.alice.web3.buckyos.test",
+            "_pkx.alice.web3.buckyos.test",
+        ] {
+            let error = resolver
+                .resolve_dns(hostname, RecordType::TXT)
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), SnResolverErrorKind::DocumentNotFound);
+        }
     }
 
     #[test]

--- a/src/components/cyfs-sn/src/sn_server.rs
+++ b/src/components/cyfs-sn/src/sn_server.rs
@@ -14,7 +14,10 @@ use crate::sn_bns_reader::BnsRpcDocumentReader;
 use crate::sn_bns_signer::{
     BoundControllerKeyManager, SnBnsControllerKeySpec, SnBnsProxyOperation, SnBnsTxSigner,
 };
-use crate::sn_compat_store::{SNDeviceInfo, SnCompatibilityStoreRef, SqliteSnCompatibilityStore};
+use crate::sn_compat_store::{
+    AuthDbRoutedSnCompatibilityStore, SNDeviceInfo, SnCompatibilityStoreRef,
+    SqliteSnCompatibilityStore,
+};
 use crate::sn_did_resolver::{
     key_like_string_to_jwk, normalize_sn_did_doc_type, owner_key_from_config, SnDidResolveRequest,
     SnDidResolverProfile, SnDidResolverRef, SnResolverBackedDidResolver,
@@ -2786,7 +2789,14 @@ impl ServerFactory for SnServerFactory {
                 e
             )
         })?;
-        let compat_store: SnCompatibilityStoreRef = Arc::new(compat_store);
+        let local_compat_store: SnCompatibilityStoreRef = Arc::new(compat_store);
+        let compat_store: SnCompatibilityStoreRef = match db_type.as_str() {
+            "postgres" | "postgresql" => Arc::new(AuthDbRoutedSnCompatibilityStore::new(
+                auth_db.clone(),
+                local_compat_store,
+            )),
+            _ => local_compat_store,
+        };
 
         let mut allocation_config = config.relay_allocation.clone().unwrap_or_default();
         allocation_config.geoip = allocation_config

--- a/src/components/cyfs-sn/tests/sn_auth_user_dns_contract.rs
+++ b/src/components/cyfs-sn/tests/sn_auth_user_dns_contract.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use cyfs_sn::{
     AuthDbRoutedSnCompatibilityStore, SnAuthDbAddUserDnsRecordReq, SnAuthDbQueryUserDnsRecordReq,
-    SnAuthDbRemoveUserDnsRecordReq, SnCompatibilityStore, SnErrorCode, SqliteSnAuthDB,
-    SqliteSnCompatibilityStore, METHOD_ADD_USER_DNS_RECORD, METHOD_LIST_USER_DNS_RECORDS,
-    METHOD_QUERY_USER_DNS_RECORD, METHOD_REMOVE_USER_DNS_RECORD,
+    SnAuthDbRemoveUserDnsRecordReq, SnCompatibilityStore, SnErrorCode, SnResolver,
+    SnResolverConfig, SnResolverErrorKind, SqliteSnAuthDB, SqliteSnCompatibilityStore,
+    METHOD_ADD_USER_DNS_RECORD, METHOD_LIST_USER_DNS_RECORDS, METHOD_QUERY_USER_DNS_RECORD,
+    METHOD_REMOVE_USER_DNS_RECORD,
 };
+use name_client::RecordType;
 
 #[test]
 fn user_dns_wire_contract_has_stable_methods_and_fields() {
@@ -156,4 +158,29 @@ async fn sqlite_baseline_keeps_multivalue_order_min_ttl_and_delete_modes() {
         .await
         .unwrap();
     assert_eq!(store.query_domain_record(name, "TXT").await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn absent_underscore_txt_record_does_not_fall_through_to_bns() {
+    let resolver = SnResolver::new(
+        SnResolverConfig::new(
+            "buckyos.test",
+            "192.0.2.10".parse().unwrap(),
+            "",
+            "",
+            Vec::new(),
+        ),
+        Arc::new(cyfs_sn::EmptySnAuthReader),
+    );
+
+    for hostname in [
+        "_acme-challenge.alice.web3.buckyos.test",
+        "_pkx.alice.web3.buckyos.test",
+    ] {
+        let error = resolver
+            .resolve_dns(hostname, RecordType::TXT)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), SnResolverErrorKind::DocumentNotFound);
+    }
 }

--- a/src/components/cyfs-sn/tests/sn_auth_user_dns_contract.rs
+++ b/src/components/cyfs-sn/tests/sn_auth_user_dns_contract.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+
+use cyfs_sn::{
+    AuthDbRoutedSnCompatibilityStore, SnAuthDbAddUserDnsRecordReq, SnAuthDbQueryUserDnsRecordReq,
+    SnAuthDbRemoveUserDnsRecordReq, SnCompatibilityStore, SnErrorCode, SqliteSnAuthDB,
+    SqliteSnCompatibilityStore, METHOD_ADD_USER_DNS_RECORD, METHOD_LIST_USER_DNS_RECORDS,
+    METHOD_QUERY_USER_DNS_RECORD, METHOD_REMOVE_USER_DNS_RECORD,
+};
+
+#[test]
+fn user_dns_wire_contract_has_stable_methods_and_fields() {
+    assert_eq!(METHOD_ADD_USER_DNS_RECORD, "sn_auth_db.add_user_dns_record");
+    assert_eq!(
+        METHOD_REMOVE_USER_DNS_RECORD,
+        "sn_auth_db.remove_user_dns_record"
+    );
+    assert_eq!(
+        METHOD_QUERY_USER_DNS_RECORD,
+        "sn_auth_db.query_user_dns_record"
+    );
+    assert_eq!(
+        METHOD_LIST_USER_DNS_RECORDS,
+        "sn_auth_db.list_user_dns_records"
+    );
+
+    let add = serde_json::to_value(SnAuthDbAddUserDnsRecordReq::new(
+        "alice",
+        "_pkx.alice.web3.example",
+        "TXT",
+        "pkx-value",
+        300,
+    ))
+    .unwrap();
+    assert_eq!(
+        add,
+        serde_json::json!({
+            "username": "alice",
+            "domain": "_pkx.alice.web3.example",
+            "record_type": "TXT",
+            "record": "pkx-value",
+            "ttl": 300
+        })
+    );
+
+    let exact_remove = serde_json::to_value(SnAuthDbRemoveUserDnsRecordReq::new(
+        "alice",
+        "_acme-challenge.alice.web3.example",
+        "TXT",
+        Some("challenge-a"),
+    ))
+    .unwrap();
+    assert_eq!(exact_remove["record"], "challenge-a");
+
+    let rrset_remove = serde_json::to_value(SnAuthDbRemoveUserDnsRecordReq::new(
+        "alice",
+        "_acme-challenge.alice.web3.example",
+        "TXT",
+        None,
+    ))
+    .unwrap();
+    assert!(rrset_remove["record"].is_null());
+
+    let query = serde_json::to_value(SnAuthDbQueryUserDnsRecordReq::new(
+        "_pkx.alice.web3.example",
+        "TXT",
+    ))
+    .unwrap();
+    assert_eq!(
+        query,
+        serde_json::json!({
+            "domain": "_pkx.alice.web3.example",
+            "record_type": "TXT"
+        })
+    );
+}
+
+#[tokio::test]
+async fn postgres_route_fails_closed_instead_of_reading_local_sqlite() {
+    let temp = tempfile::tempdir().unwrap();
+    let auth_path = temp.path().join("auth.sqlite3");
+    let compat_path = temp.path().join("compat.sqlite3");
+
+    let auth = Arc::new(
+        SqliteSnAuthDB::new_by_path(auth_path.to_string_lossy().as_ref())
+            .await
+            .unwrap(),
+    );
+    auth.initialize_database().await.unwrap();
+
+    let local = Arc::new(
+        SqliteSnCompatibilityStore::new_by_path(compat_path.to_string_lossy().as_ref())
+            .await
+            .unwrap(),
+    );
+    local.initialize_database().await.unwrap();
+    local
+        .add_user_domain("alice", "_pkx.alice.web3.example", "TXT", "local-only", 600)
+        .await
+        .unwrap();
+
+    let routed = AuthDbRoutedSnCompatibilityStore::new(auth, local.clone());
+    let error = routed
+        .query_domain_record("_pkx.alice.web3.example", "TXT")
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.code(), SnErrorCode::Failed);
+    assert_eq!(
+        local
+            .query_domain_record("_pkx.alice.web3.example", "TXT")
+            .await
+            .unwrap(),
+        Some(("local-only".to_owned(), 600))
+    );
+}
+
+#[tokio::test]
+async fn sqlite_baseline_keeps_multivalue_order_min_ttl_and_delete_modes() {
+    let temp = tempfile::tempdir().unwrap();
+    let compat_path = temp.path().join("compat.sqlite3");
+    let store = SqliteSnCompatibilityStore::new_by_path(compat_path.to_string_lossy().as_ref())
+        .await
+        .unwrap();
+    store.initialize_database().await.unwrap();
+
+    let name = "_acme-challenge.alice.web3.example";
+    store
+        .add_user_domain("alice", name, "TXT", "first", 600)
+        .await
+        .unwrap();
+    store
+        .add_user_domain("alice", name, "TXT", "second", 300)
+        .await
+        .unwrap();
+    store
+        .add_user_domain("alice", name, "TXT", "first", 120)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.query_domain_record(name, "TXT").await.unwrap(),
+        Some(("first,second".to_owned(), 120))
+    );
+
+    store
+        .remove_user_domain("alice", name, "TXT", Some("first"))
+        .await
+        .unwrap();
+    assert_eq!(
+        store.query_domain_record(name, "TXT").await.unwrap(),
+        Some(("second".to_owned(), 300))
+    );
+
+    store
+        .remove_user_domain("alice", name, "TXT", None)
+        .await
+        .unwrap();
+    assert_eq!(store.query_domain_record(name, "TXT").await.unwrap(), None);
+}


### PR DESCRIPTION
## Summary

- extend SnAuthDB and the existing auth-db S2S endpoint with add/remove/query/list user DNS methods
- route compatibility user DNS through remote SnAuthDB for db_type=postgres or postgresql while keeping device/DID compatibility state local
- preserve the default SQLite path and fail closed on provider or contract errors instead of reading process-local SQLite
- return NotFound for absent underscore-prefixed TXT control records instead of falling through to BNS and surfacing INVALID_NAME as SERVFAIL

PostgreSQL schema, driver, SQL, and provider implementation remain in the private sn-business repository. This fixes the split state where SN-API accepted _pkx and ACME records that the separate SN-DNS process could not see. Provider, SN-API, and SN-DNS must be deployed with the matching contract version.

## Verification

- `cargo check -p cyfs-sn`
- `cargo test -p cyfs-sn --test sn_auth_user_dns_contract` (3 passed)
- `cargo test -p cyfs-sn absent_underscore_txt_record_does_not_fall_through_to_bns` (1 passed)
- cross-repository task runner with private provider PostgreSQL 16 baseline and authenticated KRPC roundtrip
- four-host `.io` validation: `_pkx`, `domain.bind`, `did:web`, two-value ACME TXT, exact delete, final delete and NXDOMAIN all passed

Related: buckyos/sn-business#11 and cyfs-gateway#147
