### PR TITLE
Optimize/bns dv chain rpc

### DIFF
--- a/doc/BNS/bns-dv与SourceDAOBackend链交互对比及优化建议.md
+++ b/doc/BNS/bns-dv与SourceDAOBackend链交互对比及优化建议.md
@@ -443,87 +443,88 @@ SourceDAOBackend 的主要节省来自“大部分事件直接更新 storage”�
 - 每个 `OPT` 必须对应且只对应一次提交；实现时不得顺带合入下一项方案；
 - 当前代码快照中以下优化均未实现，因此全部标为 `[TODO]`。完成某项后，在本节把它更新为 `[DONE <full commit hash>]`。
 
-### OPT-01 `[TODO]` 抽出并统一使用 `BnsChainClient`
+### OPT-01 `[DONE ecfecafc553df6177dd8033eb4f1744fa2431f64]` 抽出并统一使用 `BnsChainClient`
 
-- **提交：** 待实现，一次提交。
+- **提交：** `ecfecafc553df6177dd8033eb4f1744fa2431f64`
 - **目标：** 在 `bns-evm` 新增单独的 `BnsChainClient` 实例，`bns_dv` 创建唯一 `Arc`，indexer 和 server 的所有直接链交互改经该实例。
 - **影响：** 只调整内部链访问边界和构造装配；RPC 方法、次数、时序和返回值保持不变。
 - **兼容：** 保留既有 public trait/构造入口；不改变 crate 依赖方向；不修改 `BnsEvmControllerClient`、cyfs-sn 或 WebUI，不把本地测试初始化使用的 Controller 接入服务侧共享实例。
 - **验收：** 现有测试全部通过；mock RPC 调用序列与改造前一致；`bns_dv` 内 indexer/server 不再各自创建长期 `EthRpcClient`。
 
-### OPT-02 `[TODO]` 用 Multicall 聚合顺序 `eth_call`
+### OPT-02 `[DONE b51c1c1f16c979a666ce49c5d3c555ab64a0cfac]` 用 Multicall 聚合顺序 `eth_call`
 
-- **提交：** 待实现，一次提交。
+- **提交：** `b51c1c1f16c979a666ce49c5d3c555ab64a0cfac`
 - **目标：** 在 `BnsChainClient` 增加 Multicall3 聚合入口，把同一投影过程或同步分片内相互独立的 latest view call 收集后一次执行；失败才回退到逐个 `eth_call`。
 - **影响：** 正常路径把一组 N 次 `eth_call` 降为 1 次，可直接大幅降低 RPC provider 的 `eth_call`/credit 消耗；继续使用现有 endpoint 和目标链能力，不新增运行服务、合约部署、上下游依赖或 Controller 改动。
 - **验收：** mock 中 N 个可聚合读取只产生一次 `eth_call`，结果与原路径逐字段一致；Multicall 失败时可靠回退；通过现有 API 页面确认 `eth_call` 消耗下降。
 
-### OPT-03 `[TODO]` 缓存链级不变量
+### OPT-03 `[DONE 7a81d8d44a247e6e2d02a29817f72b03e16a6e66]` 缓存链级不变量
 
-- **提交：** 待实现，一次提交。
+- **提交：** `7a81d8d44a247e6e2d02a29817f72b03e16a6e66`
 - **目标：** `chain_id` 和 contract address 在 `BnsChainClient` 启动时验证并缓存；只在连接切换、连续错误或低频安全审计时复核。
 - **影响：** 删除每个 `sync_once` 和每个 `system.info`/`tx.prepare` 对 chain ID 的重复读取；对外返回值不变。
 - **验收：** 空闲运行时不再每秒出现 `eth_chainId`；错误 endpoint/chain 仍能在启动或切换时被拒绝。
 
-### OPT-04 `[TODO]` 按调用来源统一链错误处理
+### OPT-04 `[DONE 60f6001ccf14952b9a1b894a69d8bed50af097b7]` 按调用来源统一链错误处理
 
-- **提交：** 待实现，一次提交。
+- **提交：** `60f6001ccf14952b9a1b894a69d8bed50af097b7`
 - **目标：** 采用 SourceDAOBackend 的简单规则：启动校验、indexer 等后台链操作发生任意错误后固定暂停 30 秒再重试；外部 API 触发的链操作发生错误时立即返回，由外部调用方重新请求。
 - **影响：** 不引入指数退避、jitter、按错误码区分的重试阶梯或请求内自动重试。正常成功路径不变；`eth_sendRawTransaction` 错误也直接返回，不在 server 内自动重发。
 - **验收：** mock 任意后台 RPC 错误后，下一次尝试固定发生在 30 秒后并能从持久化状态继续；mock `system.info`、`tx.prepare`、`tx.submit_raw`、`tx.query_state` 链错误均立即返回，单次 API 请求内没有 sleep，也不重试该次失败的 RPC。
 
-### OPT-05 `[TODO]` 改为 backlog/idle 分离的同步调度
+### OPT-05 `[DONE 7b6fcd67af2c8e533812584efcd4bc2e08626fc8]` 改为 backlog/idle 分离的同步调度
 
-- **提交：** 待实现，一次提交。
+- **提交：** `7b6fcd67af2c8e533812584efcd4bc2e08626fc8`
 - **目标：** 有 backlog 时连续处理分片；追平后才按现有 `interval_ms` sleep，默认值改为 15000 ms。将现有 `max_block_span` 默认值从 1000 改为 500，并新增 `bns_dv serve --max-block-span <n>` 覆盖入口。
 - **影响：** `interval_ms` 只控制 idle 链头检查；`max_block_span` 只控制单次 backlog 处理的区块长度。改变默认轮询间隔和分片大小，但不改变扫描边界、cursor、事件顺序或投影语义。
 - **验收：** 默认配置下，无活动时每 15 秒检查一次链头；1501 个 block 的 backlog 按 500、500、500、1 连续处理且分片间不 sleep；显式 `--interval-ms` 和 `--max-block-span` 均生效；错误路径遵循 OPT-04 的固定 30 秒等待。
 
-### OPT-06 `[TODO]` 合并 latest head 与 reorg 校验
+### OPT-06 `[DONE d5fd9d60c4640a32a3e047b7b6114784a3556c49]` 合并 latest head 与 reorg 校验
 
-- **提交：** 待实现，一次提交。
+- **提交：** `d5fd9d60c4640a32a3e047b7b6114784a3556c49`
 - **目标：** 缓存 latest header；链头不变时不重复读取同一 cursor block；链头变化时校验必要 ancestor，并保留低频同高度 reorg 审计。
 - **影响：** 减少 `eth_blockNumber + eth_getBlockByNumber(cursor)` 的重复组合；保留现有 reset/replay 行为。
 - **验收：** 15 秒 idle 配置下后台链头量接近 5,760 次/天；已有 reorg 测试继续通过；同高度 reorg 审计可触发 reset。
 
-### OPT-07 `[TODO]` transaction lookup lazy 化
+### OPT-07 `[DONE 020cc9686958d96947e110563d091db05247c21c]` transaction lookup lazy 化
 
-- **提交：** 待实现，一次提交。
+- **提交：** `020cc9686958d96947e110563d091db05247c21c`
 - **目标：** 只有 `AuthorityKeysUpdated`、`ControllerPolicyUpdated` 等真正使用 calldata 的事件才调用 `eth_getTransactionByHash`。
 - **影响：** 只删除未使用的链读取，不改变任何投影结果。
 - **验收：** 普通 name/document 事件不产生 transaction lookup；authority/controller 投影与当前结果逐字段一致。
 
-### OPT-08 `[TODO]` 缓存并合并 `tx.query_state`
+### OPT-08 `[DONE 071cd70fc4de7762704066aaec7931914946ccb4]` 缓存并合并 `tx.query_state`
 
-- **提交：** 待实现，一次提交。
+- **提交：** `071cd70fc4de7762704066aaec7931914946ccb4`
 - **目标：** 在 `BnsChainClient` 对同一 tx hash 做 singleflight、receipt cache、pending/not-found 短 TTL；确认数由共享 head 计算。
 - **影响：** kRPC、WebUI、cyfs-sn 和 controller 完全不改；短 TTL 内允许返回同一状态快照。
 - **验收：** 100 个并发相同 tx 查询在一个 TTL 窗口只形成一组上游读取；reorg 能失效相关 receipt；状态机结果不变。
 
-### OPT-09 `[TODO]` 缓存 `tx.prepare` 的不变量和 fee suggestion
+### OPT-09 `[DONE 095c24e06c3153dab1c8bedb1bb195d123dc97aa]` 缓存 `tx.prepare` 的不变量和 fee suggestion
 
-- **提交：** 待实现，一次提交。
+- **提交：** `095c24e06c3153dab1c8bedb1bb195d123dc97aa`
 - **目标：** 使用已验证 chain/contract，fee 按 head 或 2～5 秒 TTL 缓存；pending nonce 和 gas estimate 仍逐请求读取。
 - **影响：** 常规 prepare 从 5 次链 RPC 降到 2～3 次；不改变签名参数结构，不缓存任意钱包 nonce。
 - **验收：** fee cache 命中/失效符合预期；连续外部钱包交易不发生 nonce 冲突；现有 prepare 测试通过。
 
-### OPT-10 `[TODO]` 同步批次内去重 latest 状态补读
+### OPT-10 `[DONE a37ddb305b791e7de7ec7fe97deaa7fda6004fcd]` 同步批次内去重 latest 状态补读
 
-- **提交：** 待实现，一次提交。
+- **提交：** `a37ddb305b791e7de7ec7fe97deaa7fda6004fcd`
 - **目标：** 先收集完整日志分片，再按 transaction、name、document、authority、alias、checkpoint key 去重补读。
 - **影响：** 会调整一个分片内的投影组织方式，但继续从 latest 补读，event 记录顺序和最终 SQLite 状态不变。
 - **验收：** 同一交易的 NameRegistered/DocumentPublished 不重复读取同一 name；多历史变更完整追赶后最终状态与链上 latest 一致。
 
-### OPT-11 `[TODO]` 事件/calldata 优先投影
+### OPT-11 `[DONE cac7640910b2a7cdbda66cbb2fed8a2f314fa934]` 事件/calldata 优先投影
 
-- **提交：** 待实现，一次提交。
+- **提交：** `cac7640910b2a7cdbda66cbb2fed8a2f314fa934`
 - **目标：** 对 event/calldata 已包含完整信息的状态直接投影，只有信息不足时才 latest `eth_call`。
+- **实现边界：** 保留 authority key/controller rule 的 calldata 投影；checkpoint 由 event 与 calldata 完整恢复并校验 `externalAnchor`，不再调用 `latestCheckpoint`。alias `setAt`、name/document 时间字段等无法从 event/calldata 严格恢复的状态仍走 latest 补读，不猜测缺失字段。
 - **影响：** 改动 projector，范围和回归风险最大；只有 OPT-01～OPT-10 后链 API 消耗仍不达标时才实施。
 - **验收：** 固定历史区间的新旧 projector 最终 SQLite 逐字段一致；事件 hash/root 校验完整；所有业务 API 和 controller 保持不变。
 
-### OPT-12 `[TODO]` CD 系统适配：原生支持 `--cluster`
+### OPT-12 `[DONE f51428b91fc5f31a9456a168e2a146dc8df4d17a]` CD 系统适配：原生支持 `--cluster`
 
-- **提交：** 待实现，一次提交。
+- **提交：** `f51428b91fc5f31a9456a168e2a146dc8df4d17a`
 - **目标：** 为 `bns_dv serve` 新增 `--cluster` 选项。指定后由进程在启动时读取固定位置的 `/etc/cluster_config/cluster_config.json` 和 `/etc/security/security_config.json`，并映射成现有 `serve` 配置：`security.chain_rpc_url` 对应 `--rpc`，`apps.bns_dv.settings` 下的 `contract`、`chain_id`、`db`、`listen`、`start_block`、`confirmations`、`interval_ms` 分别对应现有同名命令行能力；可选 `max_block_span` 对应 OPT-05 新增的 `--max-block-span`，缺省时使用 500。
 - **覆盖规则：** 先加载 cluster/security 配置，再合并本次显式指定的其他命令行参数；命令行参数优先，覆盖文件中的对应值。未指定 `--cluster` 时完全沿用当前命令行解析、必填项和默认值行为。
 - **迁移边界：** 将当前 `start_bns_dv.ts` 中“读取和校验固定配置文件、转换为现有命令行参数”的能力下沉到 `bns_dv`；不新增另一套业务配置语义，不修改现有参数名称、Controller、链交互或上下游 API。`start_bns_dv.ts` 可在 CD 切换完成前保留为兼容入口；cluster/security 配置本身不提供 seed 或初始化交易，只有本地测试脚本显式传入 `--config`/`--seed-config` 时才进入既有初始化路径。

--- a/doc/BNS/bns-dv与SourceDAOBackend链交互对比及优化建议.md
+++ b/doc/BNS/bns-dv与SourceDAOBackend链交互对比及优化建议.md
@@ -1,0 +1,530 @@
+# bns_dv 与 SourceDAOBackend 链交互对比及优化建议
+
+## 1. 文档目的
+
+本文只比较两个 backend 与 EVM 链的交互方式，并给出 `bns_dv` 的 RPC/API 消耗优化建议。建议的边界是：
+
+- 不修改 BNS 合约接口和链上业务语义；
+- 不修改 BNS-Server 已公开的 kRPC 方法、请求和响应结构；
+- 不修改名称、文档、权限、MutationGuard 等业务规则；
+- 继续由 SQLite 投影承担业务读请求；
+- 主要调整链 RPC provider、轮询调度、事件取数、交易状态查询和缓存；
+- 对投影代码的改动只用于减少链读取，并要求优化前后投影结果一致。
+- `BnsEvmControllerClient` 只属于本地测试路径：`smoke` 冒烟，以及测试脚本通过 `serve --config`/`--seed-config` 配合 Anvil 从零初始化完整 SN 集群；它不进入正式服务生命周期。本轮不修改 Controller，也不把它接入 `BnsChainClient`。
+
+对比代码快照：
+
+- `cyfs-gateway`: `4e1f391c95eb42803751d4a98a7ec2c958134ad8`
+- `SourceDAOBackend`: `af0b1fff3b833acb15bfe1550e1d93437c68a07a`
+- 分析日期：2026-08-05
+
+这里的调用量是根据代码路径做的静态估算，不代表线上账单。上线改动前后通过现有 API 页面和 RPC 服务侧数据校准即可，不需要为此在代码中新增观测。
+
+## 2. 结论摘要
+
+`bns_dv` 的普通业务读已经走 SQLite 投影，这一点与 SourceDAOBackend 的方向一致。正式服务由 indexer 和 server handler 完成链交互，不使用 Controller。当前高消耗主要不在普通 BNS 查询，而在以下三个链交互路径：
+
+1. **空闲轮询过密且每轮重复读取不变量。** 默认 `interval_ms=1000` 时，投影追平后每轮仍调用一次 `eth_chainId`、一次 `eth_blockNumber`、一次 `eth_getBlockByNumber`。约为 **259,200 次/天**。SourceDAOBackend 的链头轮询是每 15 秒一次、每次一次 `eth_getBlockByNumber("latest")`，约 **5,760 次/天**。
+2. **事件投影先无条件读取交易，再按每条事件回读合约状态。** `bns-indexer` 对每个 registry event 都先进入 `decoded_call_for_log`；即使只有 authority/controller 事件真正使用 calldata，也会对几乎每笔有业务事件的交易调用 `eth_getTransactionByHash`。随后多数事件还会产生 1～2 次 `eth_call`，同一名称在同一交易内也可能被重复读取。
+3. **客户端交易状态与链 RPC 一一放大。** 每次 `tx.query_state` 都需要两次上游 RPC：`eth_getTransactionReceipt` 加 `eth_blockNumber`，或者 `eth_getTransactionReceipt` 加 `eth_getTransactionByHash`。前端会按 2 秒、5 秒、15 秒分段持续轮询，多个用户或恢复出的历史未完成交易会线性放大上游消耗。
+
+建议先做不改变投影语义的优化：
+
+1. 首先在现有下层 crate `bns-evm` 中抽出一个长期存在的 `BnsChainClient`，由 `bns_dv` 创建单实例并注入 indexer 和 server；以后 `bns_dv` 进程内的链交互尽量集中在该实例中。
+2. 参考 SourceDAOBackend，在 `BnsChainClient` 内把一次投影过程中的多次独立 latest `eth_call` 聚合为一次 Multicall；继续使用现有 RPC endpoint，聚合失败才回退到逐个 `eth_call`。
+3. 再在 `BnsChainClient` 内缓存 chain ID、latest head、fee 和 receipt，并提供 singleflight。
+4. 链错误处理直接采用 SourceDAOBackend 的简单规则：后台链操作失败后固定暂停 30 秒再重试；外部 API 触发的链操作失败则立即返回错误，由调用方重新请求。
+5. 将同步器改成“backlog 连续处理、追平后按 `interval_ms` 休眠”；`interval_ms` 默认 15 秒。每个 backlog 分片默认处理 500 个 block，并可通过 `--max-block-span` 调整。
+6. 只对确实需要 calldata 的事件读取交易，并在一个同步批次内去重 name/document/transaction 读取。
+7. 最后再评估事件/calldata 优先投影等影响更大的方案。
+
+`BnsChainClient` 收敛本身不改变调用量；在这个基础上完成 chain ID 缓存、状态感知调度以及 latest head/reorg 合并后，按 15 秒空闲间隔估算，后台空闲请求可从约 259,200 次/天下降到约 5,760 次/天，下降约 **97.8%**，同时不降低历史追赶速度。
+
+## 3. 对比范围与公平性说明
+
+SourceDAOBackend 可以作为 indexer 和 backend 读写隔离的基准，但不能直接认为它的所有链交互都优于 BNS：
+
+- SourceDAOBackend 不为浏览器或 SN 提供 raw transaction relay，也不提供 backend 侧的实时交易状态接口；BNS 的 `tx.prepare`、`tx.submit_raw`、`tx.query_state` 是额外产品能力。
+- BNS 保存游标 block hash 并主动检查 reorg；SourceDAOBackend 只保存下一个扫描块高，没有等价的 block hash/reorg 校验。优化时应保留 BNS 的正确性能力，不能直接删除重组检查。
+- 两边在处理历史事件时，部分补充 `eth_call` 默认读 `latest`。对当前“最终状态投影”模型这是可接受的：无后续变更时 latest 即正确状态；有后续变更时，较早事件可能暂时读到未来状态，但继续追到后续事件后会再次收敛到同一正确最新状态。历史追赶期间 backend 本来也不适合承接写操作。
+
+因此本文把问题拆为两部分：
+
+- indexer 的固定后台消耗：可以直接参考 SourceDAOBackend；
+- BNS 独有的交易服务消耗：保持 API 不变，在 server 内部做共享、缓存、合并和退避。
+
+## 4. 当前链交互全景
+
+### 4.1 bns_dv
+
+长驻进程入口在 [`bns_dv.rs`](../../src/components/bns-server/src/bin/bns_dv.rs)。`serve` 同时启动：
+
+- `BnsContractEventIndexer`：轮询链并写 SQLite；
+- `BnsContractServerHandler`：普通读查 SQLite，交易相关接口直连链；
+
+目前 indexer 和 server handler 分别创建自己的 `EthRpcClient`。虽然 `reqwest::Client` 在单个实例内能复用连接，但两者之间没有共享链头、chain ID、receipt 或 fee 数据。`BnsEvmControllerClient` 不属于正式服务运行时链访问模型，只在以下本地测试初始化路径使用：
+
+- `smoke` 子命令执行跨分层冒烟；
+- 测试脚本以 `serve --config`/`--seed-config` 进入 `run_on_init_txs`，配合 Anvil 从零构造并启动完整的本地 SN 集群。
+
+这两条路径都属于测试基础设施，不是正式 CD 服务启动方式。它们应继续保持可用，但不纳入服务侧 `BnsChainClient` 的共享、缓存或调度改造；新增的 `serve --cluster` 也不得隐式触发本地初始化交易。
+
+#### Indexer 每次 `sync_once`
+
+代码位置：[`bns-indexer/src/sync.rs`](../../src/components/bns-indexer/src/sync.rs)。
+
+| 阶段 | 当前 RPC | 触发频率 |
+| --- | --- | --- |
+| 校验网络 | `eth_chainId` | 每次 `sync_once` |
+| 读取链头 | `eth_blockNumber` | 每次 `sync_once` |
+| 检查 reorg | `eth_getBlockByNumber(cursor.block_number)` | 已有带 hash 游标时，每次 `sync_once`，即使链头没变 |
+| 拉事件 | `eth_getLogs` | 有待同步区间时，每个最多 1000 block 的分片一次 |
+| 解交易 calldata | `eth_getTransactionByHash` | 当前对每个 registry event 都尝试；同一 `sync_once` 内按 tx hash 去重 |
+| 补名称状态 | `eth_call(queryNameState)` | 多数名称事件一次；文档、alias 等事件也会再次调用 |
+| 补文档状态 | `eth_call(getDocumentVersion)` | document publish/revoke/payment 事件各一次 |
+| 补 authority/alias/checkpoint | 对应 `eth_call` | 对应事件各一次 |
+| 保存游标 hash | `eth_getBlockByNumber(to_block)` | 每个实际完成的同步分片一次 |
+
+正常已有游标且投影追平时，一次循环固定是 3 次 RPC：
+
+```text
+eth_chainId
+eth_blockNumber
+eth_getBlockByNumber(cursor)
+```
+
+因此当前空闲日调用量近似为：
+
+```text
+3 * 86,400,000 / interval_ms
+```
+
+Rust 命令行缺省值和仓库内 `web3-gateway/start.py` 都是 1000 ms；正式线上实例如果由外部 cluster settings 覆盖，应先代入实际 `interval_ms`，再与 RPC 账单核对。
+
+有新区间时，一次同步分片的基础调用量为：
+
+```text
+5 + T + C
+```
+
+其中：
+
+- 5 = chain ID、链头、旧游标 hash、getLogs、新游标 hash；
+- `T` = 该分片中包含 registry event 的不同交易数；
+- `C` = 各事件触发的合约状态 `eth_call` 数。
+
+例如同一笔注册交易产生 `NameRegistered` 和一个 `DocumentPublished` 时，当前路径通常至少增加一次 transaction lookup、一次名称读取、一次重复名称读取和一次文档读取。也就是说，该分片大致会产生 9 次 RPC，而不是只有链头和 `getLogs` 两次。
+
+#### BNS-Server 方法
+
+代码位置：[`bns-server/src/lib.rs`](../../src/components/bns-server/src/lib.rs)。
+
+| BNS 方法 | 当前上游链 RPC | 单次调用量 |
+| --- | --- | ---: |
+| 普通名称、owner、authority、document、event 查询 | 无，读取 SQLite | 0 |
+| `system.info` | `eth_chainId` | 1 |
+| `tx.prepare` | chain ID、pending nonce、estimate gas、gas price、priority fee | 5 |
+| `tx.submit_raw` | `eth_sendRawTransaction` | 1 |
+| `tx.query_state`，未出 receipt | receipt + transaction by hash | 2 |
+| `tx.query_state`，已有 receipt | receipt + latest block number | 2 |
+
+`tx.prepare` 中的 chain ID 和 contract address 实际是进程级不变量，但现在每次都通过 `system_info()` 重新读链。fee 的两个读取也没有短 TTL 或按区块缓存。
+
+`tx.query_state` 没有 receipt 缓存、pending/not-found 缓存或相同 tx hash 的并发合并。即使 receipt 已经确认，下一次查询仍重新读取 receipt 和链头。
+
+#### 客户端对 `tx.query_state` 的放大
+
+BNS WebUI 默认轮询策略位于 [`config.ts`](../../src/apps/bns-webui/src/bns_model/config.ts)：
+
+- 前 30 秒：每 2 秒一次；
+- 30 秒～5 分钟：每 5 秒一次；
+- 之后：每 15 秒一次；
+- `not_found` 和 `indexer_lagging` 不是终态，可持续轮询。
+
+在 server 没有缓存的情况下，单笔交易仅前 30 秒约产生 15～16 次 BNS 查询，即约 30～32 次链 RPC；持续到 5 分钟约产生 138 次链 RPC；进入 tail 阶段后仍约为 8 次链 RPC/分钟。多个浏览器、多个本地恢复记录和 SN receipt waiter 会叠加。
+
+SN 注册等待使用 500 ms 的默认 receipt 间隔。它通过 BNS-Server 查询时，一笔活跃注册最多可形成约 4 次上游链 RPC/秒。
+
+### 4.2 SourceDAOBackend
+
+主要链逻辑集中在 `/root/work/SourceDAOBackend/src/server/src/chain_client.rs`，HTTP handler 只访问 storage 或内存 status。
+
+#### 启动阶段
+
+- 创建一个长期存在的 Alloy `DynProvider`，所有合约实例共享该 provider；
+- provider 配置最多 3 次重试、3 秒重试间隔；
+- 一次性读取各子合约地址和 chain ID；
+- token symbol/decimals 只在首次填充时逐项读取；
+- 7 个 token/treasury 数值通过一次 Multicall 聚合读取，失败才降级为 7 次独立 `eth_call`。
+
+#### 长驻阶段
+
+- 链扫描追平后 sleep 15 秒；
+- 一次 `eth_getBlockByNumber("latest")` 同时得到 block number 和 timestamp；
+- 发现新区间后，用一次合并 address filter 的 `eth_getLogs` 读取所有关注合约的事件；
+- 追赶历史区间时不 sleep，直到再次超过已知链头；
+- 大部分事件直接使用 log 字段更新 storage；只有事件中缺少必要详情时才 `eth_call`；只有 `ProjectCreate` 等确实需要发送者信息时才读取 transaction；
+- token/treasury 状态约每 60 秒用一次 Multicall 刷新；
+- `/status`、`/contract/info`、`/contract/token` 等 HTTP API 返回内存状态，不把一次用户请求直接放大成一次链请求。
+
+SourceDAOBackend 的静态空闲后台量约为：
+
+```text
+链头轮询：86400 / 15 = 5,760 次/天
+token Multicall：最多约 86400 / 60 = 1,440 次/天
+合计：约 7,200 次/天（不含启动和真实链事件）
+```
+
+## 5. 关键差异
+
+| 维度 | bns_dv | SourceDAOBackend | 对 bns_dv 的影响 |
+| --- | --- | --- | --- |
+| provider 生命周期 | indexer、server 各自创建 client | 一个 provider clone 给所有合约实例 | `bns_dv` 内无法共享链头、fee、receipt 和限流状态 |
+| chain ID | 每个 `sync_once`；`system.info`/`tx.prepare` 也会读取 | 启动时读取并缓存 | 纯固定消耗，且随 API 请求放大 |
+| 空闲链头间隔 | 默认 1 秒 | 15 秒 | indexer 固定调用量相差 45 倍 |
+| 链头信息 | `eth_blockNumber`，hash 另查 | 一次 latest block 同时拿 number/timestamp | BNS 每轮方法数更多 |
+| 追赶调度 | 每个分片后仍 sleep `interval_ms` | 有 backlog 时连续扫描 | BNS 空闲过快、追赶反而被人为减速 |
+| 失败调度 | 下一轮通常 1 秒后重试 | event 失败等 30 秒，provider 还有重试配置 | 限流/故障时 BNS 容易形成持续压力 |
+| reorg | 每轮检查 cursor block hash | 无显式 hash 检查 | BNS 更正确，但检查频率不合理 |
+| transaction lookup | 所有 registry event 都先尝试读取 tx | 只有确需 signer 等信息的事件才读取 | BNS 对普通事件产生额外请求 |
+| 合约状态补读 | 多数事件 1～2 次，且同批次会重复读相同 name | 大部分直接用 event，少数补读 | BNS 请求量随事件数快速增长 |
+| 批量读取 | 没有 JSON-RPC batch/Multicall | 7 个周期性 view call 用 Multicall | BNS 多个独立 `eth_call` 无法聚合 |
+| 用户 API | tx/system/prepare 会同步打链 | handler 基本只读 DB/内存 | BNS 流量随在线用户和未完成交易数增长 |
+| receipt 策略 | 每次查询重新读；无 singleflight/TTL | backend 不提供对应能力 | BNS 独有的主要活动流量源 |
+| RPC 健壮性 | 自定义 reqwest client，无显式 timeout/retry/backoff | Alloy provider 有 retry；业务循环有较长退避 | 故障时既不稳定也不节流 |
+
+## 6. 建议的目标链访问模型
+
+在现有下层 crate `bns-evm` 内引入 `BnsChainClient`。它内部持有现有 `EthRpcClient` transport 和共享运行状态，只负责链交互，不承载 BNS 业务规则。
+
+`bns_dv serve` 启动时创建一个 `Arc<BnsChainClient>`，注入：
+
+- `BnsContractEventIndexer`；
+- `BnsContractServerHandler`；
+- 后续新增的、属于 `bns_dv` 进程内的链访问能力。
+
+上述组件不再直接创建或长期持有各自的 `EthRpcClient`，而是通过同一个 `BnsChainClient` 访问链。为了不改变上下游依赖：
+
+- `BnsChainClient` 放在 indexer/server 已经依赖的 `bns-evm`，不新增反向依赖或 crate 依赖环；
+- 保留现有 public trait、构造入口和数据结构，新增注入构造入口供 `bns_dv` 使用；旧入口可内部创建独立 `BnsChainClient` 作为兼容包装；
+- 不修改 `BnsEvmControllerClient` 及任何 controller 代码，不把 Controller 注入正式服务路径；`smoke` 和本地 SN 集群初始化路径保持独立；
+- 不要求其他进程注入或共享 `bns_dv` 的内存实例；其他进程通过现有 BNS API 与 `bns_dv` 交互；
+- 不修改 BNS-Server、BNS-Indexer、cyfs-sn、WebUI 的公开 API 和依赖方向。
+
+建议维护以下状态：
+
+- 启动时验证后的 `chain_id`、contract address；
+- 最新链头 `{number, hash, parent_hash, fetched_at}`；
+- 最近一次通过 reorg 校验的 cursor/head；
+- 短 TTL fee suggestion；
+- 按 tx hash 缓存的 receipt/pending/not-found 状态；
+- 相同 key 并发请求的 singleflight；
+- 后台同步状态，用于区分 backlog、idle 和错误后的固定 30 秒等待。
+
+同时由该实例提供 Multicall 聚合入口：接收一组相互独立、使用同一 block tag 的合约只读调用，一次提交到目标链已有的 Multicall3，按原顺序解码结果；聚合失败时才退回现有逐个 `eth_call` 路径。
+
+普通业务读仍然直接读取 SQLite，不经过该层。
+
+## 7. 候选优化详细说明
+
+本节说明各项候选改动的技术内容，不代表提交顺序。实际优先级、状态和“一项方案对应一次提交”的拆分见第 11 节。
+
+### 7.1 统一 `BnsChainClient` 边界
+
+第一步只做结构收敛，不同时加入缓存或改变 RPC 行为：
+
+- 在 `bns-evm` 新增 `BnsChainClient`，内部委托现有 `EthRpcClient`；
+- `bns_dv` 只创建一个实例；
+- indexer/server 新增接收 `Arc<BnsChainClient>` 的构造入口；
+- 现有构造入口和测试入口继续可用；
+- 将 indexer/server 的直接 RPC 调用改为通过该实例；
+- controller 代码以及本地测试初始化路径使用的 `EthRpcClient` 保持不动，不纳入服务侧共享实例。
+
+这个提交的验收目标是“调用结果和调用次数完全不变，但链访问入口已经集中”，为后续把优化限制在 `BnsChainClient` 内创造条件。
+
+### 7.2 用 Multicall 聚合顺序 `eth_call`
+
+SourceDAOBackend 已经把 7 个顺序执行的 token/treasury view call 通过 Alloy provider 的 `multicall().add(...).aggregate()` 合成一次 `eth_call`，仅在聚合失败时回退为 7 次独立调用。这个优化的目标就是减少 RPC provider 统计的 `eth_call`/credit 消耗，而不只是减少 HTTP 往返。
+
+`bns_dv` 可以采用同样方式：
+
+- 在 `BnsChainClient` 内提供 Multicall3 聚合方法，indexer/server 不直接依赖具体 ABI 和地址处理；
+- 使用现有 RPC endpoint、现有进程和目标链已有的 Multicall3，不新增服务、endpoint、合约部署或 Controller 依赖；
+- 将同一投影过程或同步分片中相互独立、都读取 `latest` 的 name/document/authority/alias/checkpoint 调用收集后一次执行；
+- 保持调用与返回值的稳定顺序，并分别使用原有 ABI 解码，业务结果不变；
+- 聚合失败时回退到现有逐个 `eth_call`，保证兼容性，但回退只作为异常路径。
+
+一组 `N` 个顺序 `eth_call` 在正常路径会变为 1 个 `eth_call`。这与 JSON-RPC batch 不同：batch 只减少 HTTP 往返，provider 仍可能逐个统计内部 method；Multicall3 在链上执行多个只读调用，对 RPC provider 表现为一次 `eth_call`。本方案不改变上下游接口和依赖方向，也不需要修改 controller。
+
+### 7.3 状态感知的同步调度
+
+把固定 `sync_once -> sleep(interval)` 改为：
+
+1. 启动时校验一次 chain ID；连接重建、连续错误或低频安全审计时再复核，而不是每秒复核。
+2. 有 backlog 时按 block range 连续处理，成功完成一个分片后立即处理下一个分片，不执行 idle sleep。
+3. 每个 backlog 分片使用现有 `BnsIndexerSyncConfig.max_block_span`，默认值从 1000 调整为 500，并由 `bns_dv serve --max-block-span <n>` 覆盖。
+4. 追平后按现有 `interval_ms` 进入 idle sleep，再读取一次 latest block header；`interval_ms` 默认值从 1000 ms 调整为 15000 ms，继续由现有 `--interval-ms` 覆盖。
+5. 后台同步中的任意链操作失败时，本轮终止并固定暂停 30 秒，然后从持久化 cursor 重试；不设计多级指数退避或 jitter。
+
+这样 `interval_ms` 只控制已经追平后的链头检查频率，不再限制历史追赶速度；`max_block_span` 只控制单次 backlog 请求和事务的规模。
+
+### 7.4 合并链头读取并降低 reorg 检查频率
+
+当前 `eth_blockNumber` 只给高度，随后还要查 block hash。建议以 latest block header 为主：
+
+- `confirmations=0` 且 cursor 正好位于 head 时，latest header 的 hash 可同时完成链头读取和 cursor 校验；
+- 链头没有变化时，不重复读取同一个 cursor block；
+- 链头前进时，在处理新区间前校验一次必要 ancestor；
+- 为防同高度 reorg，可额外做 30～60 秒一次的低频 hash 审计；
+- 发生 reorg 后继续沿用当前 reset/replay 语义。
+
+这不是删除 reorg 检测，而是把“每秒重复验证同一事实”改为“链头变化驱动 + 低频兜底”。
+
+### 7.5 按调用来源统一链错误处理
+
+直接采用 SourceDAOBackend 的固定策略，不在 `BnsChainClient` 内设计复杂的重试、指数退避、jitter 或调用方限流状态：
+
+- 启动校验、indexer 等由 backend 自主管理的后台链操作发生任何错误时，结束本轮处理，固定暂停 30 秒后从持久化状态重试；
+- `system.info`、`tx.prepare`、`tx.submit_raw`、`tx.query_state` 等由外部 API 请求触发的链操作发生错误时，立即把错误返回给调用方，不在请求生命周期内 sleep 或自动重试；
+- 外部调用方沿用现有重试或重新发起请求的机制，backend 不替它延长单次请求；
+- Multicall 聚合失败时仍可先走既定的逐个 `eth_call` 兼容回退；若回退也失败，则按上述后台/API 来源处理。
+
+这使错误语义只保留“后台 30 秒后重试”和“外部请求立即失败”两种，不需要为不同 JSON-RPC 错误码维护不同退避阶梯。`eth_sendRawTransaction` 也不在 server 内自动重发，避免网络结果不确定时重复提交。
+
+### 7.6 只在需要 calldata 时读取 transaction
+
+当前调用顺序是先对每条 registry event 执行 `decoded_call_for_log`，再进入 `projection_for_record`。但 calldata 当前只被以下投影使用：
+
+- `AuthorityKeysUpdated`：恢复 authority key updates；
+- `ControllerPolicyUpdated`：恢复 controller rules。
+
+应先识别 event 类型，只有这两类或以后明确需要 calldata 的类型才调用 `eth_getTransactionByHash`。这个改动不改变投影值，是低风险高收益项。
+
+### 7.7 同一同步批次收集、去重后再读取
+
+先解码整个 `eth_getLogs` 结果，建立需要补读的唯一 key 集合：
+
+- transaction hash；
+- name；
+- `(name, doc_type, version)`；
+- authority set、alias、checkpoint。
+
+然后统一从 `latest` 读取并回填投影，避免同一交易的 `NameRegistered + DocumentPublished` 对同一 name 重复 `queryNameState`。
+
+这里继续使用 `latest` 是有意选择，而不是待修复的历史精确性问题：
+
+- 久远事件之后没有同类状态变更时，latest 就是该事件最终应投影的状态；
+- 久远事件之后还有状态变更时，较早事件补读可能提前得到未来状态，但继续处理后续事件时会再次读到并收敛到相同的最新正确状态；
+- event log 本身仍按真实事件顺序和内容持久化，latest 只用于补充当前状态投影；
+- catch-up 未完成时 backend 不适合承接依赖最新 guard/state 的写操作，因此不要求暴露每个历史瞬间的可操作中间态。
+
+收集、去重后的调用直接交给 7.2 的 Multicall 聚合入口。JSON-RPC batch 仍只作为减少 HTTP 往返的可选 transport 优化，不能替代 Multicall；调用量效果通过现有 API 页面和 RPC 服务侧数据验证，不在代码中新增统计。
+
+### 7.8 `tx.query_state` 的 singleflight 与分状态缓存
+
+在不修改 kRPC 行为和 controller 的前提下，在 server 使用的 `BnsChainClient` 内实现：
+
+- 同一 tx hash 的并发查询合并为一个上游请求；
+- receipt 一旦存在，缓存 receipt 的 status、block number、block hash；确认数用共享最新链头计算，不再每次重复读取 receipt 和 `eth_blockNumber`；
+- 未确认 receipt 使用 1～2 秒短 TTL；pending/not-found 使用 2～5 秒 TTL；
+- `eth_getTransactionByHash` 只用于区分 pending 和 not-found，可用比 receipt 更长的 10～30 秒 TTL；
+- indexer 已观察到某 tx 的 log 时，可给状态缓存提供“该交易已成功进入某区块”的正向提示，但不能作为所有交易状态的唯一来源；
+- reorg 发生时，失效受影响区块之后的 terminal receipt cache。
+
+这样多个 WebUI/SN 同时查询一笔交易时，上游调用量由“客户端数 × 轮询次数 × 2”收敛为“每个 TTL 窗口最多一组读取”。WebUI、cyfs-sn 和 controller 代码均不需要修改。
+
+### 7.9 `tx.prepare` 缓存不变量和 fee
+
+保持 nonce 和 gas estimate 的实时性，但在 server 使用的 `BnsChainClient` 内减少其他调用：
+
+- chain ID 和 contract address 使用启动时已验证的值；
+- fee suggestion 按最新区块或 2～5 秒 TTL 缓存；
+- 支持时可用一次 `eth_feeHistory` 生成 EIP-1559 建议，或用现有 transport 实现 JSON-RPC batch；
+- `eth_getTransactionCount(from, "pending")` 对任意外部钱包仍按请求读取，不建议像托管 signer 一样长期缓存 nonce；
+- `eth_estimateGas` 仍按 calldata 读取。
+
+常规 `tx.prepare` 可从 5 次链 RPC 降为 2 次（fee cache 命中）或 3 次（需要刷新 fee），而不改变客户端签名参数结构。
+
+### 7.10 事件/calldata 优先，缺失字段才回链
+
+SourceDAOBackend 的主要节省来自“大部分事件直接更新 storage”。BNS 也可以逐事件迁移：
+
+- NameRegistered/Renewed/Transferred/OwnerUpdated/Released 等先用 event 字段对本地状态应用 delta；
+- alias、namespace、owner IAT floor、checkpoint 等 event 已携带主要变更值，优先直接投影；
+- document 内容和 authority/controller 规则可从已签名交易 calldata 恢复，并用 event 中的 hash/root 校验；
+- 只有 event 和 calldata 都不足以重建的字段才执行 latest `eth_call`。
+
+这是影响范围最大、风险最高的候选项，会触及 projector，而不仅是 RPC 调度。必须以同一批历史区块同时跑旧、新 projector，对 SQLite 最终结果做逐字段 diff 后再切换。只有前述优化仍不能满足目标时才实施。
+
+## 8. 不建议直接照搬 SourceDAOBackend 的部分
+
+1. **不要删除 BNS reorg 检测。** SourceDAOBackend 没有同等级检测，这不是需要复制的差异。
+2. **不要修改 controller，也不要把它引入正式服务路径。** `bns_dv` 的 Controller 只服务于 `smoke` 和基于 Anvil 的本地完整 SN 集群初始化；正式服务的链访问只由 indexer 和 server handler 完成。
+3. **不要改变上下游依赖。** `BnsChainClient` 应放在现有公共下层并保留兼容入口，不能让 `bns-evm` 反向依赖 indexer/server，也不能要求调用方改变公开 API。
+4. **不需要为历史补读引入 block tag。** 当前目标是最终最新状态投影，使用 latest 能在追赶结束后正确收敛，且改动更集中。
+5. **不要为了减少 RPC 缓存任意钱包的 nonce。** SourceDAOBackend 不承担 relay；BNS `tx.prepare` 面对外部钱包时必须读取 pending nonce。
+6. **不要用 JSON-RPC batch 代替 Multicall。** batch 内的子请求仍可能被 RPC provider 分别计数；Multicall 才是把多个 view call 合成一个 `eth_call` 的主要降耗路径。实际降幅通过现有 API 页面和 RPC 服务侧数据验证。
+7. **不要只把 interval 调大。** 固定大间隔会同时拖慢历史追赶；正确方式是 backlog 与 idle 使用不同调度。
+
+## 9. 建议的改动文件边界
+
+第一项 `BnsChainClient` 收敛方案只应触及既有链交互和装配文件：
+
+- `src/components/bns-evm/src/rpc.rs`
+  - 保留底层 JSON-RPC transport；
+- `src/components/bns-evm/src/lib.rs`
+  - 导出新增 chain client module/type；
+- `src/components/bns-evm/src/chain_client.rs`（建议新增）
+  - `BnsChainClient`、共享链配置和后续运行态缓存的唯一归属；
+- `src/components/bns-indexer/src/sync.rs`
+  - 新增 chain client 注入入口，链调用改经 `BnsChainClient`；
+- `src/components/bns-server/src/lib.rs`
+  - 新增 chain client 注入入口，server 链调用改经 `BnsChainClient`；
+- `src/components/bns-server/src/bin/bns_dv.rs`
+  - 创建并装配唯一 `Arc<BnsChainClient>`。
+
+第一阶段不需要修改：
+
+- BNS Solidity 合约和 ABI；
+- `BnsIndexerApi` 对外方法签名；
+- `BnsEvmControllerClient` 及其他 controller 代码；
+- 现有 crate 依赖方向和上下游公开构造/调用关系；
+- BNS WebUI 轮询状态机；
+- cyfs-sn 注册、DNS 和鉴权业务流程；
+- SQLite 中名称、文档、权限等业务 schema。
+
+如果实施 7.10 的事件 delta projector，会修改 `bns-indexer` 的投影实现，但其输入、输出和持久化业务语义必须保持不变，应作为独立后续改动。
+
+## 10. 验证与验收建议
+
+### 10.1 RPC 调用量测试
+
+扩展现有 mock RPC 测试，至少钉死：
+
+1. 已追平、链头不变的 N 次调度：chain ID 不随 N 重复，cursor block hash 不每轮重复读取。
+2. 新区间出现：每个 range 只有一次 `eth_getLogs`；默认每次最多处理 500 个 block，`--max-block-span` 能覆盖该值，追赶期间不执行 idle sleep。
+3. 同一组 N 个独立 view call 在 Multicall 正常路径只产生一次 `eth_call`，各项返回值与逐个调用一致；聚合失败时能回退到 N 次原有调用。
+4. 普通 Name/Document 事件不会无条件触发 `eth_getTransactionByHash`；authority/controller 仍能正确恢复 calldata。
+5. 同批次相同 name 和 document key 只补读一次。
+6. 100 个并发 `tx.query_state(same_hash)` 在同一 TTL 窗口最多形成一组上游 receipt/transaction 请求。
+7. terminal receipt 重复查询不再读取 receipt；确认数随共享 head 正确增加。
+8. 后台链操作发生任意错误后固定等待 30 秒再重试；相同错误发生在外部 API 请求路径时立即返回，server 内不 sleep，也不重试该次失败的 RPC。
+9. reorg 后 cursor reset、投影重放和 receipt cache 失效仍与当前语义一致。
+
+### 10.2 投影一致性测试
+
+- 用固定历史区块范围分别运行优化前后 indexer；
+- 比较 names、documents、authority sets/keys、aliases、controller policies、events、checkpoint 和 cursor；
+- 对 register、applyMutations、多文档、release、alias、authority/controller 更新分别覆盖；
+- 增加“同一名称在多个历史块连续变化”的 catch-up 用例，验证较早事件即使从 latest 提前读到最终状态，完整追赶后的 SQLite 最终状态仍与链上 latest 一致。
+
+### 10.3 线上验收数据
+
+建议通过现有 API 页面和 RPC 服务侧数据，以 24 小时窗口观察：
+
+- 无链活动时，后台链头请求接近 `86400 / idle_interval_seconds`，15 秒间隔约 5,760 次/天，而不是 259,200 次/天；
+- `eth_chainId` 只在启动、低频审计或连接切换时出现；
+- 没有新区间时不出现每秒 `eth_getBlockByNumber(cursor)`；
+- 有 backlog 时按默认 500 block 分片连续处理；发生链错误后，相邻后台尝试之间约隔 30 秒；
+- 可聚合的连续 view call 在正常路径按组表现为一次 `eth_call`，逐个 `eth_call` 只在 Multicall 回退路径出现；
+- transaction lookup 数量接近真正需要 calldata/signer 的交易数，而不是所有 registry transaction 数；
+- `tx.query_state` 上游请求量不随同一 tx 的并发客户端数线性增长；
+- indexer lag、交易确认延迟和现有 API 错误率没有回归；
+- reorg 测试仍能自动 reset/replay。
+
+## 11. 优化实施方案
+
+以下顺序同时表示实施优先级：越靠前优先级越高。在依赖关系允许的情况下，方案大致按改动影响范围和回归风险从小到大排列。`OPT-01` 虽涉及多个构造位置，但只做内部结构收敛、不改变行为，是所有后续方案的前置条件。
+
+状态标记规则：
+
+- `[TODO]`：尚未实现；
+- `[DONE <full commit hash>]`：已经通过一次独立提交实现；
+- 每个 `OPT` 必须对应且只对应一次提交；实现时不得顺带合入下一项方案；
+- 当前代码快照中以下优化均未实现，因此全部标为 `[TODO]`。完成某项后，在本节把它更新为 `[DONE <full commit hash>]`。
+
+### OPT-01 `[TODO]` 抽出并统一使用 `BnsChainClient`
+
+- **提交：** 待实现，一次提交。
+- **目标：** 在 `bns-evm` 新增单独的 `BnsChainClient` 实例，`bns_dv` 创建唯一 `Arc`，indexer 和 server 的所有直接链交互改经该实例。
+- **影响：** 只调整内部链访问边界和构造装配；RPC 方法、次数、时序和返回值保持不变。
+- **兼容：** 保留既有 public trait/构造入口；不改变 crate 依赖方向；不修改 `BnsEvmControllerClient`、cyfs-sn 或 WebUI，不把本地测试初始化使用的 Controller 接入服务侧共享实例。
+- **验收：** 现有测试全部通过；mock RPC 调用序列与改造前一致；`bns_dv` 内 indexer/server 不再各自创建长期 `EthRpcClient`。
+
+### OPT-02 `[TODO]` 用 Multicall 聚合顺序 `eth_call`
+
+- **提交：** 待实现，一次提交。
+- **目标：** 在 `BnsChainClient` 增加 Multicall3 聚合入口，把同一投影过程或同步分片内相互独立的 latest view call 收集后一次执行；失败才回退到逐个 `eth_call`。
+- **影响：** 正常路径把一组 N 次 `eth_call` 降为 1 次，可直接大幅降低 RPC provider 的 `eth_call`/credit 消耗；继续使用现有 endpoint 和目标链能力，不新增运行服务、合约部署、上下游依赖或 Controller 改动。
+- **验收：** mock 中 N 个可聚合读取只产生一次 `eth_call`，结果与原路径逐字段一致；Multicall 失败时可靠回退；通过现有 API 页面确认 `eth_call` 消耗下降。
+
+### OPT-03 `[TODO]` 缓存链级不变量
+
+- **提交：** 待实现，一次提交。
+- **目标：** `chain_id` 和 contract address 在 `BnsChainClient` 启动时验证并缓存；只在连接切换、连续错误或低频安全审计时复核。
+- **影响：** 删除每个 `sync_once` 和每个 `system.info`/`tx.prepare` 对 chain ID 的重复读取；对外返回值不变。
+- **验收：** 空闲运行时不再每秒出现 `eth_chainId`；错误 endpoint/chain 仍能在启动或切换时被拒绝。
+
+### OPT-04 `[TODO]` 按调用来源统一链错误处理
+
+- **提交：** 待实现，一次提交。
+- **目标：** 采用 SourceDAOBackend 的简单规则：启动校验、indexer 等后台链操作发生任意错误后固定暂停 30 秒再重试；外部 API 触发的链操作发生错误时立即返回，由外部调用方重新请求。
+- **影响：** 不引入指数退避、jitter、按错误码区分的重试阶梯或请求内自动重试。正常成功路径不变；`eth_sendRawTransaction` 错误也直接返回，不在 server 内自动重发。
+- **验收：** mock 任意后台 RPC 错误后，下一次尝试固定发生在 30 秒后并能从持久化状态继续；mock `system.info`、`tx.prepare`、`tx.submit_raw`、`tx.query_state` 链错误均立即返回，单次 API 请求内没有 sleep，也不重试该次失败的 RPC。
+
+### OPT-05 `[TODO]` 改为 backlog/idle 分离的同步调度
+
+- **提交：** 待实现，一次提交。
+- **目标：** 有 backlog 时连续处理分片；追平后才按现有 `interval_ms` sleep，默认值改为 15000 ms。将现有 `max_block_span` 默认值从 1000 改为 500，并新增 `bns_dv serve --max-block-span <n>` 覆盖入口。
+- **影响：** `interval_ms` 只控制 idle 链头检查；`max_block_span` 只控制单次 backlog 处理的区块长度。改变默认轮询间隔和分片大小，但不改变扫描边界、cursor、事件顺序或投影语义。
+- **验收：** 默认配置下，无活动时每 15 秒检查一次链头；1501 个 block 的 backlog 按 500、500、500、1 连续处理且分片间不 sleep；显式 `--interval-ms` 和 `--max-block-span` 均生效；错误路径遵循 OPT-04 的固定 30 秒等待。
+
+### OPT-06 `[TODO]` 合并 latest head 与 reorg 校验
+
+- **提交：** 待实现，一次提交。
+- **目标：** 缓存 latest header；链头不变时不重复读取同一 cursor block；链头变化时校验必要 ancestor，并保留低频同高度 reorg 审计。
+- **影响：** 减少 `eth_blockNumber + eth_getBlockByNumber(cursor)` 的重复组合；保留现有 reset/replay 行为。
+- **验收：** 15 秒 idle 配置下后台链头量接近 5,760 次/天；已有 reorg 测试继续通过；同高度 reorg 审计可触发 reset。
+
+### OPT-07 `[TODO]` transaction lookup lazy 化
+
+- **提交：** 待实现，一次提交。
+- **目标：** 只有 `AuthorityKeysUpdated`、`ControllerPolicyUpdated` 等真正使用 calldata 的事件才调用 `eth_getTransactionByHash`。
+- **影响：** 只删除未使用的链读取，不改变任何投影结果。
+- **验收：** 普通 name/document 事件不产生 transaction lookup；authority/controller 投影与当前结果逐字段一致。
+
+### OPT-08 `[TODO]` 缓存并合并 `tx.query_state`
+
+- **提交：** 待实现，一次提交。
+- **目标：** 在 `BnsChainClient` 对同一 tx hash 做 singleflight、receipt cache、pending/not-found 短 TTL；确认数由共享 head 计算。
+- **影响：** kRPC、WebUI、cyfs-sn 和 controller 完全不改；短 TTL 内允许返回同一状态快照。
+- **验收：** 100 个并发相同 tx 查询在一个 TTL 窗口只形成一组上游读取；reorg 能失效相关 receipt；状态机结果不变。
+
+### OPT-09 `[TODO]` 缓存 `tx.prepare` 的不变量和 fee suggestion
+
+- **提交：** 待实现，一次提交。
+- **目标：** 使用已验证 chain/contract，fee 按 head 或 2～5 秒 TTL 缓存；pending nonce 和 gas estimate 仍逐请求读取。
+- **影响：** 常规 prepare 从 5 次链 RPC 降到 2～3 次；不改变签名参数结构，不缓存任意钱包 nonce。
+- **验收：** fee cache 命中/失效符合预期；连续外部钱包交易不发生 nonce 冲突；现有 prepare 测试通过。
+
+### OPT-10 `[TODO]` 同步批次内去重 latest 状态补读
+
+- **提交：** 待实现，一次提交。
+- **目标：** 先收集完整日志分片，再按 transaction、name、document、authority、alias、checkpoint key 去重补读。
+- **影响：** 会调整一个分片内的投影组织方式，但继续从 latest 补读，event 记录顺序和最终 SQLite 状态不变。
+- **验收：** 同一交易的 NameRegistered/DocumentPublished 不重复读取同一 name；多历史变更完整追赶后最终状态与链上 latest 一致。
+
+### OPT-11 `[TODO]` 事件/calldata 优先投影
+
+- **提交：** 待实现，一次提交。
+- **目标：** 对 event/calldata 已包含完整信息的状态直接投影，只有信息不足时才 latest `eth_call`。
+- **影响：** 改动 projector，范围和回归风险最大；只有 OPT-01～OPT-10 后链 API 消耗仍不达标时才实施。
+- **验收：** 固定历史区间的新旧 projector 最终 SQLite 逐字段一致；事件 hash/root 校验完整；所有业务 API 和 controller 保持不变。
+
+### OPT-12 `[TODO]` CD 系统适配：原生支持 `--cluster`
+
+- **提交：** 待实现，一次提交。
+- **目标：** 为 `bns_dv serve` 新增 `--cluster` 选项。指定后由进程在启动时读取固定位置的 `/etc/cluster_config/cluster_config.json` 和 `/etc/security/security_config.json`，并映射成现有 `serve` 配置：`security.chain_rpc_url` 对应 `--rpc`，`apps.bns_dv.settings` 下的 `contract`、`chain_id`、`db`、`listen`、`start_block`、`confirmations`、`interval_ms` 分别对应现有同名命令行能力；可选 `max_block_span` 对应 OPT-05 新增的 `--max-block-span`，缺省时使用 500。
+- **覆盖规则：** 先加载 cluster/security 配置，再合并本次显式指定的其他命令行参数；命令行参数优先，覆盖文件中的对应值。未指定 `--cluster` 时完全沿用当前命令行解析、必填项和默认值行为。
+- **迁移边界：** 将当前 `start_bns_dv.ts` 中“读取和校验固定配置文件、转换为现有命令行参数”的能力下沉到 `bns_dv`；不新增另一套业务配置语义，不修改现有参数名称、Controller、链交互或上下游 API。`start_bns_dv.ts` 可在 CD 切换完成前保留为兼容入口；cluster/security 配置本身不提供 seed 或初始化交易，只有本地测试脚本显式传入 `--config`/`--seed-config` 时才进入既有初始化路径。
+- **验收：** 仅指定 `--cluster` 可以按两个固定配置文件成功启动，且进程中不创建或调用 `BnsEvmControllerClient`；显式 `--rpc`、`--contract`、`--chain-id`、`--db`、`--listen`、`--start-block`、`--confirmations`、`--interval-ms`、`--max-block-span` 分别能覆盖文件值；缺失、类型错误和非法路径等配置继续启动失败并给出明确错误；不指定 `--cluster` 的现有启动命令以及测试脚本显式使用 `--config`/`--seed-config` 的本地集群初始化行为保持不变。

--- a/src/components/bns-evm/Cargo.toml
+++ b/src/components/bns-evm/Cargo.toml
@@ -16,6 +16,4 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-
-[dev-dependencies]
 tokio.workspace = true

--- a/src/components/bns-evm/src/chain_client.rs
+++ b/src/components/bns-evm/src/chain_client.rs
@@ -1,12 +1,53 @@
-use alloy_primitives::{Address, Bytes, B256};
-use alloy_sol_types::SolCall;
+use alloy_primitives::{address, Address, Bytes, B256};
+use alloy_sol_types::{sol, SolCall};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::{
-    BnsEvmResult, Eip1559FeeSuggestion, EthBlock, EthLog, EthRpcClient, EthTransaction,
-    EthTransactionReceipt, RpcLogFilter,
+    BnsEvmError, BnsEvmResult, Eip1559FeeSuggestion, EthBlock, EthLog, EthRpcClient,
+    EthTransaction, EthTransactionReceipt, RpcLogFilter,
 };
+
+sol! {
+    interface Multicall3 {
+        struct Call {
+            address target;
+            bytes callData;
+        }
+
+        function aggregate(Call[] calldata calls)
+            external
+            payable
+            returns (uint256 blockNumber, bytes[] memory returnData);
+    }
+}
+
+pub const MULTICALL3_ADDRESS: Address = address!("cA11bde05977b3631167028862bE2a173976CA11");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContractRead {
+    pub target: Address,
+    pub calldata: Bytes,
+}
+
+impl ContractRead {
+    pub fn new<C>(target: Address, call: &C) -> Self
+    where
+        C: SolCall,
+    {
+        Self {
+            target,
+            calldata: call.abi_encode().into(),
+        }
+    }
+}
+
+pub fn decode_contract_return<C>(output: &[u8]) -> BnsEvmResult<C::Return>
+where
+    C: SolCall,
+{
+    C::abi_decode_returns(output).map_err(|err| BnsEvmError::Abi(err.to_string()))
+}
 
 /// Shared entry point for all long-lived BNS service access to an EVM chain.
 ///
@@ -80,6 +121,41 @@ impl BnsChainClient {
         C: SolCall,
     {
         self.rpc.call_contract(to, call).await
+    }
+
+    /// Execute independent latest-state reads through Multicall3.
+    ///
+    /// A missing or incompatible Multicall3 deployment is transparent to
+    /// callers: the original calls are replayed individually in order.
+    pub async fn multicall(&self, calls: &[ContractRead]) -> BnsEvmResult<Vec<Bytes>> {
+        if calls.len() <= 1 {
+            return self.call_individually(calls).await;
+        }
+
+        let aggregate = Multicall3::aggregateCall {
+            calls: calls
+                .iter()
+                .map(|call| Multicall3::Call {
+                    target: call.target,
+                    callData: call.calldata.clone(),
+                })
+                .collect(),
+        };
+        if let Ok(result) = self.rpc.call_contract(MULTICALL3_ADDRESS, &aggregate).await {
+            if result.returnData.len() == calls.len() {
+                return Ok(result.returnData);
+            }
+        }
+
+        self.call_individually(calls).await
+    }
+
+    async fn call_individually(&self, calls: &[ContractRead]) -> BnsEvmResult<Vec<Bytes>> {
+        let mut outputs = Vec::with_capacity(calls.len());
+        for call in calls {
+            outputs.push(self.rpc.eth_call(call.target, &call.calldata).await?);
+        }
+        Ok(outputs)
     }
 
     pub async fn get_logs(&self, filter: &RpcLogFilter) -> BnsEvmResult<Vec<EthLog>> {

--- a/src/components/bns-evm/src/chain_client.rs
+++ b/src/components/bns-evm/src/chain_client.rs
@@ -29,6 +29,7 @@ sol! {
 pub const MULTICALL3_ADDRESS: Address = address!("cA11bde05977b3631167028862bE2a173976CA11");
 const PENDING_TRANSACTION_TTL: Duration = Duration::from_secs(2);
 const NOT_FOUND_TRANSACTION_TTL: Duration = Duration::from_secs(5);
+const FEE_SUGGESTION_TTL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContractRead {
@@ -47,6 +48,13 @@ pub enum TransactionLookup {
 struct CachedTransactionLookup {
     state: TransactionLookup,
     expires_at: Option<Instant>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CachedFeeSuggestion {
+    fees: Eip1559FeeSuggestion,
+    head_hash: Option<B256>,
+    expires_at: Instant,
 }
 
 impl ContractRead {
@@ -82,6 +90,8 @@ pub struct BnsChainClient {
     latest_block: Mutex<Option<EthBlock>>,
     transaction_cache: Mutex<HashMap<B256, CachedTransactionLookup>>,
     transaction_locks: Mutex<HashMap<B256, Arc<tokio::sync::Mutex<()>>>>,
+    fee_cache: Mutex<Option<CachedFeeSuggestion>>,
+    fee_lock: tokio::sync::Mutex<()>,
 }
 
 impl BnsChainClient {
@@ -94,6 +104,8 @@ impl BnsChainClient {
             latest_block: Mutex::new(None),
             transaction_cache: Mutex::new(HashMap::new()),
             transaction_locks: Mutex::new(HashMap::new()),
+            fee_cache: Mutex::new(None),
+            fee_lock: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -110,6 +122,8 @@ impl BnsChainClient {
             latest_block: Mutex::new(None),
             transaction_cache: Mutex::new(HashMap::new()),
             transaction_locks: Mutex::new(HashMap::new()),
+            fee_cache: Mutex::new(None),
+            fee_lock: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -274,7 +288,41 @@ impl BnsChainClient {
     }
 
     pub async fn suggest_eip1559_fees(&self) -> BnsEvmResult<Eip1559FeeSuggestion> {
-        self.rpc.suggest_eip1559_fees().await
+        if let Some(fees) = self.cached_fee_suggestion() {
+            return Ok(fees);
+        }
+        let _guard = self.fee_lock.lock().await;
+        if let Some(fees) = self.cached_fee_suggestion() {
+            return Ok(fees);
+        }
+
+        let fees = self.rpc.suggest_eip1559_fees().await?;
+        let head_hash = self
+            .latest_block
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|head| head.hash);
+        *self.fee_cache.lock().unwrap() = Some(CachedFeeSuggestion {
+            fees,
+            head_hash,
+            expires_at: Instant::now() + FEE_SUGGESTION_TTL,
+        });
+        Ok(fees)
+    }
+
+    fn cached_fee_suggestion(&self) -> Option<Eip1559FeeSuggestion> {
+        let current_head_hash = self
+            .latest_block
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|head| head.hash);
+        let cache = self.fee_cache.lock().unwrap();
+        cache.as_ref().and_then(|cached| {
+            (cached.expires_at > Instant::now() && cached.head_hash == current_head_hash)
+                .then_some(cached.fees)
+        })
     }
 
     pub async fn estimate_gas(

--- a/src/components/bns-evm/src/chain_client.rs
+++ b/src/components/bns-evm/src/chain_client.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use alloy_primitives::{address, Address, Bytes, B256};
 use alloy_sol_types::{sol, SolCall};
 use serde::de::DeserializeOwned;
@@ -57,12 +59,31 @@ where
 #[derive(Debug)]
 pub struct BnsChainClient {
     rpc: EthRpcClient,
+    expected_chain_id: Option<u64>,
+    contract_address: Option<Address>,
+    chain_id: OnceLock<u64>,
 }
 
 impl BnsChainClient {
     pub fn new(endpoint: impl Into<String>) -> Self {
         Self {
             rpc: EthRpcClient::new(endpoint),
+            expected_chain_id: None,
+            contract_address: None,
+            chain_id: OnceLock::new(),
+        }
+    }
+
+    pub fn new_with_chain_config(
+        endpoint: impl Into<String>,
+        contract_address: Address,
+        chain_id: u64,
+    ) -> Self {
+        Self {
+            rpc: EthRpcClient::new(endpoint),
+            expected_chain_id: Some(chain_id),
+            contract_address: Some(contract_address),
+            chain_id: OnceLock::new(),
         }
     }
 
@@ -75,8 +96,32 @@ impl BnsChainClient {
         &self.rpc
     }
 
+    pub fn configured_chain_id(&self) -> Option<u64> {
+        self.expected_chain_id
+    }
+
+    pub fn contract_address(&self) -> Option<Address> {
+        self.contract_address
+    }
+
+    pub async fn validate_chain(&self) -> BnsEvmResult<()> {
+        self.chain_id().await.map(|_| ())
+    }
+
     pub async fn chain_id(&self) -> BnsEvmResult<u64> {
-        self.rpc.chain_id().await
+        if let Some(chain_id) = self.chain_id.get() {
+            return Ok(*chain_id);
+        }
+        let actual = self.rpc.chain_id().await?;
+        if let Some(expected) = self.expected_chain_id {
+            if actual != expected {
+                return Err(BnsEvmError::Rpc(format!(
+                    "BNS chain id mismatch: configured {expected}, RPC returned {actual}"
+                )));
+            }
+        }
+        let _ = self.chain_id.set(actual);
+        Ok(actual)
     }
 
     pub async fn block_number(&self) -> BnsEvmResult<u64> {

--- a/src/components/bns-evm/src/chain_client.rs
+++ b/src/components/bns-evm/src/chain_client.rs
@@ -1,0 +1,117 @@
+use alloy_primitives::{Address, Bytes, B256};
+use alloy_sol_types::SolCall;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::{
+    BnsEvmResult, Eip1559FeeSuggestion, EthBlock, EthLog, EthRpcClient, EthTransaction,
+    EthTransactionReceipt, RpcLogFilter,
+};
+
+/// Shared entry point for all long-lived BNS service access to an EVM chain.
+///
+/// The first implementation intentionally delegates one-for-one to the
+/// existing transport. Later optimizations can therefore be contained here
+/// without changing the indexer or server public APIs.
+#[derive(Debug)]
+pub struct BnsChainClient {
+    rpc: EthRpcClient,
+}
+
+impl BnsChainClient {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            rpc: EthRpcClient::new(endpoint),
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        self.rpc.endpoint()
+    }
+
+    /// Compatibility access for callers that still need the raw transport.
+    pub fn rpc(&self) -> &EthRpcClient {
+        &self.rpc
+    }
+
+    pub async fn chain_id(&self) -> BnsEvmResult<u64> {
+        self.rpc.chain_id().await
+    }
+
+    pub async fn block_number(&self) -> BnsEvmResult<u64> {
+        self.rpc.block_number().await
+    }
+
+    pub async fn transaction_count(&self, address: Address) -> BnsEvmResult<u64> {
+        self.rpc.transaction_count(address).await
+    }
+
+    pub async fn gas_price(&self) -> BnsEvmResult<u128> {
+        self.rpc.gas_price().await
+    }
+
+    pub async fn max_priority_fee_per_gas(&self) -> BnsEvmResult<u128> {
+        self.rpc.max_priority_fee_per_gas().await
+    }
+
+    pub async fn suggest_eip1559_fees(&self) -> BnsEvmResult<Eip1559FeeSuggestion> {
+        self.rpc.suggest_eip1559_fees().await
+    }
+
+    pub async fn estimate_gas(
+        &self,
+        from: Address,
+        to: Address,
+        calldata: &[u8],
+    ) -> BnsEvmResult<u64> {
+        self.rpc.estimate_gas(from, to, calldata).await
+    }
+
+    pub async fn send_raw_transaction(&self, raw_tx: &[u8]) -> BnsEvmResult<B256> {
+        self.rpc.send_raw_transaction(raw_tx).await
+    }
+
+    pub async fn eth_call(&self, to: Address, calldata: &[u8]) -> BnsEvmResult<Bytes> {
+        self.rpc.eth_call(to, calldata).await
+    }
+
+    pub async fn call_contract<C>(&self, to: Address, call: &C) -> BnsEvmResult<C::Return>
+    where
+        C: SolCall,
+    {
+        self.rpc.call_contract(to, call).await
+    }
+
+    pub async fn get_logs(&self, filter: &RpcLogFilter) -> BnsEvmResult<Vec<EthLog>> {
+        self.rpc.get_logs(filter).await
+    }
+
+    pub async fn block_by_number(&self, block_number: u64) -> BnsEvmResult<Option<EthBlock>> {
+        self.rpc.block_by_number(block_number).await
+    }
+
+    pub async fn transaction_by_hash(&self, tx_hash: B256) -> BnsEvmResult<Option<EthTransaction>> {
+        self.rpc.transaction_by_hash(tx_hash).await
+    }
+
+    pub async fn transaction_receipt(
+        &self,
+        tx_hash: B256,
+    ) -> BnsEvmResult<Option<EthTransactionReceipt>> {
+        self.rpc.transaction_receipt(tx_hash).await
+    }
+
+    pub async fn call<R>(&self, method: &str, params: Value) -> BnsEvmResult<R>
+    where
+        R: DeserializeOwned,
+    {
+        self.rpc.call(method, params).await
+    }
+
+    pub async fn call_nullable<R>(&self, method: &str, params: Value) -> BnsEvmResult<Option<R>>
+    where
+        R: DeserializeOwned,
+    {
+        self.rpc.call_nullable(method, params).await
+    }
+}

--- a/src/components/bns-evm/src/chain_client.rs
+++ b/src/components/bns-evm/src/chain_client.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use alloy_primitives::{address, Address, Bytes, B256};
 use alloy_sol_types::{sol, SolCall};
@@ -62,6 +62,7 @@ pub struct BnsChainClient {
     expected_chain_id: Option<u64>,
     contract_address: Option<Address>,
     chain_id: OnceLock<u64>,
+    latest_block: Mutex<Option<EthBlock>>,
 }
 
 impl BnsChainClient {
@@ -71,6 +72,7 @@ impl BnsChainClient {
             expected_chain_id: None,
             contract_address: None,
             chain_id: OnceLock::new(),
+            latest_block: Mutex::new(None),
         }
     }
 
@@ -84,6 +86,7 @@ impl BnsChainClient {
             expected_chain_id: Some(chain_id),
             contract_address: Some(contract_address),
             chain_id: OnceLock::new(),
+            latest_block: Mutex::new(None),
         }
     }
 
@@ -126,6 +129,30 @@ impl BnsChainClient {
 
     pub async fn block_number(&self) -> BnsEvmResult<u64> {
         self.rpc.block_number().await
+    }
+
+    /// Return the latest header and whether it differs from the previously
+    /// cached header. Backlog processing can pass `false` to reuse one head.
+    pub async fn latest_block(&self, refresh: bool) -> BnsEvmResult<(EthBlock, bool)> {
+        if !refresh {
+            if let Some(block) = self.latest_block.lock().unwrap().clone() {
+                return Ok((block, false));
+            }
+        }
+
+        let block = self
+            .rpc
+            .latest_block()
+            .await?
+            .ok_or_else(|| BnsEvmError::Rpc("latest EVM block is missing".to_string()))?;
+        let mut cached = self.latest_block.lock().unwrap();
+        let changed = cached.as_ref() != Some(&block);
+        *cached = Some(block.clone());
+        Ok((block, changed))
+    }
+
+    pub fn cached_latest_block(&self) -> Option<EthBlock> {
+        self.latest_block.lock().unwrap().clone()
     }
 
     pub async fn transaction_count(&self, address: Address) -> BnsEvmResult<u64> {

--- a/src/components/bns-evm/src/chain_client.rs
+++ b/src/components/bns-evm/src/chain_client.rs
@@ -1,4 +1,6 @@
-use std::sync::{Mutex, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use alloy_primitives::{address, Address, Bytes, B256};
 use alloy_sol_types::{sol, SolCall};
@@ -25,11 +27,26 @@ sol! {
 }
 
 pub const MULTICALL3_ADDRESS: Address = address!("cA11bde05977b3631167028862bE2a173976CA11");
+const PENDING_TRANSACTION_TTL: Duration = Duration::from_secs(2);
+const NOT_FOUND_TRANSACTION_TTL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContractRead {
     pub target: Address,
     pub calldata: Bytes,
+}
+
+#[derive(Debug, Clone)]
+pub enum TransactionLookup {
+    Mined(EthTransactionReceipt),
+    Pending,
+    NotFound,
+}
+
+#[derive(Debug, Clone)]
+struct CachedTransactionLookup {
+    state: TransactionLookup,
+    expires_at: Option<Instant>,
 }
 
 impl ContractRead {
@@ -63,6 +80,8 @@ pub struct BnsChainClient {
     contract_address: Option<Address>,
     chain_id: OnceLock<u64>,
     latest_block: Mutex<Option<EthBlock>>,
+    transaction_cache: Mutex<HashMap<B256, CachedTransactionLookup>>,
+    transaction_locks: Mutex<HashMap<B256, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl BnsChainClient {
@@ -73,6 +92,8 @@ impl BnsChainClient {
             contract_address: None,
             chain_id: OnceLock::new(),
             latest_block: Mutex::new(None),
+            transaction_cache: Mutex::new(HashMap::new()),
+            transaction_locks: Mutex::new(HashMap::new()),
         }
     }
 
@@ -87,6 +108,8 @@ impl BnsChainClient {
             contract_address: Some(contract_address),
             chain_id: OnceLock::new(),
             latest_block: Mutex::new(None),
+            transaction_cache: Mutex::new(HashMap::new()),
+            transaction_locks: Mutex::new(HashMap::new()),
         }
     }
 
@@ -146,13 +169,96 @@ impl BnsChainClient {
             .await?
             .ok_or_else(|| BnsEvmError::Rpc("latest EVM block is missing".to_string()))?;
         let mut cached = self.latest_block.lock().unwrap();
+        let reorg_from = cached
+            .as_ref()
+            .and_then(|previous| reorg_invalidation_start(previous, &block));
         let changed = cached.as_ref() != Some(&block);
         *cached = Some(block.clone());
+        drop(cached);
+        if let Some(block_number) = reorg_from {
+            self.invalidate_mined_receipts_from(block_number);
+        }
         Ok((block, changed))
     }
 
     pub fn cached_latest_block(&self) -> Option<EthBlock> {
         self.latest_block.lock().unwrap().clone()
+    }
+
+    pub async fn transaction_lookup(&self, tx_hash: B256) -> BnsEvmResult<TransactionLookup> {
+        if let Some(state) = self.cached_transaction_lookup(tx_hash) {
+            return Ok(state);
+        }
+
+        let lock = {
+            let mut locks = self.transaction_locks.lock().unwrap();
+            locks
+                .entry(tx_hash)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        let guard = lock.lock().await;
+        if let Some(state) = self.cached_transaction_lookup(tx_hash) {
+            drop(guard);
+            self.remove_unused_transaction_lock(tx_hash, &lock);
+            return Ok(state);
+        }
+
+        let state = match self.rpc.transaction_receipt(tx_hash).await? {
+            Some(receipt) => TransactionLookup::Mined(receipt),
+            None => match self.rpc.transaction_by_hash(tx_hash).await? {
+                Some(_) => TransactionLookup::Pending,
+                None => TransactionLookup::NotFound,
+            },
+        };
+        let expires_at = match state {
+            TransactionLookup::Mined(_) => None,
+            TransactionLookup::Pending => Some(Instant::now() + PENDING_TRANSACTION_TTL),
+            TransactionLookup::NotFound => Some(Instant::now() + NOT_FOUND_TRANSACTION_TTL),
+        };
+        self.transaction_cache.lock().unwrap().insert(
+            tx_hash,
+            CachedTransactionLookup {
+                state: state.clone(),
+                expires_at,
+            },
+        );
+        drop(guard);
+        self.remove_unused_transaction_lock(tx_hash, &lock);
+        Ok(state)
+    }
+
+    pub fn invalidate_mined_receipts_from(&self, block_number: u64) {
+        self.transaction_cache
+            .lock()
+            .unwrap()
+            .retain(|_, cached| match &cached.state {
+                TransactionLookup::Mined(receipt) => receipt
+                    .block_number
+                    .is_none_or(|number| number < block_number),
+                TransactionLookup::Pending | TransactionLookup::NotFound => true,
+            });
+    }
+
+    fn cached_transaction_lookup(&self, tx_hash: B256) -> Option<TransactionLookup> {
+        let now = Instant::now();
+        let mut cache = self.transaction_cache.lock().unwrap();
+        let expired = cache
+            .get(&tx_hash)
+            .and_then(|cached| cached.expires_at)
+            .is_some_and(|expires_at| expires_at <= now);
+        if expired {
+            cache.remove(&tx_hash);
+            return None;
+        }
+        cache.get(&tx_hash).map(|cached| cached.state.clone())
+    }
+
+    fn remove_unused_transaction_lock(&self, tx_hash: B256, lock: &Arc<tokio::sync::Mutex<()>>) {
+        let mut locks = self.transaction_locks.lock().unwrap();
+        if Arc::strong_count(lock) == 2 {
+            locks.remove(&tx_hash);
+        }
     }
 
     pub async fn transaction_count(&self, address: Address) -> BnsEvmResult<u64> {
@@ -261,5 +367,25 @@ impl BnsChainClient {
         R: DeserializeOwned,
     {
         self.rpc.call_nullable(method, params).await
+    }
+}
+
+fn reorg_invalidation_start(previous: &EthBlock, current: &EthBlock) -> Option<u64> {
+    match (previous.number, current.number) {
+        (Some(previous_number), Some(current_number)) if current_number < previous_number => {
+            Some(current_number.saturating_add(1))
+        }
+        (Some(previous_number), Some(current_number))
+            if current_number == previous_number && current.hash != previous.hash =>
+        {
+            Some(current_number)
+        }
+        (Some(previous_number), Some(current_number))
+            if current_number == previous_number.saturating_add(1)
+                && current.parent_hash != previous.hash =>
+        {
+            Some(0)
+        }
+        _ => None,
     }
 }

--- a/src/components/bns-evm/src/lib.rs
+++ b/src/components/bns-evm/src/lib.rs
@@ -21,7 +21,7 @@ pub use bindings::{
     OwnerPolicyUpdate, OwnerResolution, OwnerSource, Principal, PrincipalKind, PurchaseContext,
     RegisterOptions, ReleaseMode, ResolveResult,
 };
-pub use chain_client::BnsChainClient;
+pub use chain_client::{decode_contract_return, BnsChainClient, ContractRead, MULTICALL3_ADDRESS};
 pub use rpc::{
     BlockRange, Eip1559FeeSuggestion, EthBlock, EthLog, EthRpcClient, EthTransaction,
     EthTransactionReceipt, RpcLogFilter,

--- a/src/components/bns-evm/src/lib.rs
+++ b/src/components/bns-evm/src/lib.rs
@@ -1,5 +1,6 @@
 //! EVM ABI, transaction signing, JSON-RPC, and event helpers for the BNS contract.
 
+mod chain_client;
 mod rpc;
 mod tx;
 
@@ -20,9 +21,10 @@ pub use bindings::{
     OwnerPolicyUpdate, OwnerResolution, OwnerSource, Principal, PrincipalKind, PurchaseContext,
     RegisterOptions, ReleaseMode, ResolveResult,
 };
+pub use chain_client::BnsChainClient;
 pub use rpc::{
-    BlockRange, Eip1559FeeSuggestion, EthLog, EthRpcClient, EthTransaction, EthTransactionReceipt,
-    RpcLogFilter,
+    BlockRange, Eip1559FeeSuggestion, EthBlock, EthLog, EthRpcClient, EthTransaction,
+    EthTransactionReceipt, RpcLogFilter,
 };
 pub use tx::{
     build_eip1559_contract_tx, decode_signed_eip1559, encode_call, sign_eip1559_tx,

--- a/src/components/bns-evm/src/lib.rs
+++ b/src/components/bns-evm/src/lib.rs
@@ -21,7 +21,9 @@ pub use bindings::{
     OwnerPolicyUpdate, OwnerResolution, OwnerSource, Principal, PrincipalKind, PurchaseContext,
     RegisterOptions, ReleaseMode, ResolveResult,
 };
-pub use chain_client::{decode_contract_return, BnsChainClient, ContractRead, MULTICALL3_ADDRESS};
+pub use chain_client::{
+    decode_contract_return, BnsChainClient, ContractRead, TransactionLookup, MULTICALL3_ADDRESS,
+};
 pub use rpc::{
     BlockRange, Eip1559FeeSuggestion, EthBlock, EthLog, EthRpcClient, EthTransaction,
     EthTransactionReceipt, RpcLogFilter,

--- a/src/components/bns-evm/src/rpc.rs
+++ b/src/components/bns-evm/src/rpc.rs
@@ -74,7 +74,7 @@ impl EthLog {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EthBlock {
     #[serde(default, deserialize_with = "deserialize_optional_quantity")]
@@ -246,6 +246,11 @@ impl EthRpcClient {
             json!([quantity_hex(block_number), false]),
         )
         .await
+    }
+
+    pub async fn latest_block(&self) -> BnsEvmResult<Option<EthBlock>> {
+        self.call_nullable("eth_getBlockByNumber", json!(["latest", false]))
+            .await
     }
 
     pub async fn transaction_by_hash(&self, tx_hash: B256) -> BnsEvmResult<Option<EthTransaction>> {

--- a/src/components/bns-evm/tests/chain_client_cache.rs
+++ b/src/components/bns-evm/tests/chain_client_cache.rs
@@ -1,0 +1,139 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bns_evm::{BnsChainClient, TransactionLookup, B256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const TX_HASH: &str = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+struct MockRpc {
+    endpoint: String,
+    receipt_calls: Arc<AtomicUsize>,
+    transaction_calls: Arc<AtomicUsize>,
+}
+
+impl MockRpc {
+    async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let receipt_calls = Arc::new(AtomicUsize::new(0));
+        let transaction_calls = Arc::new(AtomicUsize::new(0));
+        let receipt_counter = receipt_calls.clone();
+        let transaction_counter = transaction_calls.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let receipt_counter = receipt_counter.clone();
+                let transaction_counter = transaction_counter.clone();
+                tokio::spawn(async move {
+                    let request = read_http_request(&mut stream).await;
+                    let body = request
+                        .split_once("\r\n\r\n")
+                        .map(|(_, body)| body)
+                        .unwrap_or_default();
+                    let request: serde_json::Value = serde_json::from_str(body).unwrap();
+                    let method = request["method"].as_str().unwrap_or_default();
+                    let result = match method {
+                        "eth_getTransactionReceipt" => {
+                            receipt_counter.fetch_add(1, Ordering::SeqCst);
+                            tokio::time::sleep(Duration::from_millis(25)).await;
+                            serde_json::json!({
+                                "transactionHash": TX_HASH,
+                                "blockNumber": "0x8",
+                                "status": "0x1"
+                            })
+                        }
+                        "eth_getTransactionByHash" => {
+                            transaction_counter.fetch_add(1, Ordering::SeqCst);
+                            serde_json::Value::Null
+                        }
+                        _ => serde_json::Value::Null,
+                    };
+                    let response_body = serde_json::to_string(&serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request["id"],
+                        "result": result,
+                    }))
+                    .unwrap();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    stream.write_all(response.as_bytes()).await.unwrap();
+                });
+            }
+        });
+        Self {
+            endpoint,
+            receipt_calls,
+            transaction_calls,
+        }
+    }
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut buffer = Vec::new();
+    let mut chunk = [0u8; 2048];
+    loop {
+        let size = stream.read(&mut chunk).await.unwrap();
+        if size == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..size]);
+        let Some(header_end) = buffer.windows(4).position(|part| part == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&buffer[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                line.split_once(':').and_then(|(name, value)| {
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+            })
+            .unwrap_or(0);
+        if buffer.len() >= header_end + 4 + content_length {
+            break;
+        }
+    }
+    String::from_utf8(buffer).unwrap()
+}
+
+#[tokio::test]
+async fn concurrent_transaction_queries_share_and_cache_receipt() {
+    let mock = MockRpc::start().await;
+    let client = Arc::new(BnsChainClient::new(&mock.endpoint));
+    let tx_hash: B256 = TX_HASH.parse().unwrap();
+
+    let mut tasks = Vec::new();
+    for _ in 0..100 {
+        let client = client.clone();
+        tasks.push(tokio::spawn(async move {
+            match client.transaction_lookup(tx_hash).await.unwrap() {
+                TransactionLookup::Mined(receipt) => assert_eq!(receipt.block_number, Some(8)),
+                TransactionLookup::Pending | TransactionLookup::NotFound => {
+                    panic!("expected mined receipt")
+                }
+            }
+        }));
+    }
+    for task in tasks {
+        task.await.unwrap();
+    }
+
+    assert_eq!(mock.receipt_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(mock.transaction_calls.load(Ordering::SeqCst), 0);
+    client.transaction_lookup(tx_hash).await.unwrap();
+    assert_eq!(mock.receipt_calls.load(Ordering::SeqCst), 1);
+
+    client.invalidate_mined_receipts_from(8);
+    client.transaction_lookup(tx_hash).await.unwrap();
+    assert_eq!(mock.receipt_calls.load(Ordering::SeqCst), 2);
+}

--- a/src/components/bns-evm/tests/chain_client_cache.rs
+++ b/src/components/bns-evm/tests/chain_client_cache.rs
@@ -12,6 +12,8 @@ struct MockRpc {
     endpoint: String,
     receipt_calls: Arc<AtomicUsize>,
     transaction_calls: Arc<AtomicUsize>,
+    gas_price_calls: Arc<AtomicUsize>,
+    priority_fee_calls: Arc<AtomicUsize>,
 }
 
 impl MockRpc {
@@ -20,8 +22,12 @@ impl MockRpc {
         let endpoint = format!("http://{}", listener.local_addr().unwrap());
         let receipt_calls = Arc::new(AtomicUsize::new(0));
         let transaction_calls = Arc::new(AtomicUsize::new(0));
+        let gas_price_calls = Arc::new(AtomicUsize::new(0));
+        let priority_fee_calls = Arc::new(AtomicUsize::new(0));
         let receipt_counter = receipt_calls.clone();
         let transaction_counter = transaction_calls.clone();
+        let gas_price_counter = gas_price_calls.clone();
+        let priority_fee_counter = priority_fee_calls.clone();
         tokio::spawn(async move {
             loop {
                 let Ok((mut stream, _)) = listener.accept().await else {
@@ -29,6 +35,8 @@ impl MockRpc {
                 };
                 let receipt_counter = receipt_counter.clone();
                 let transaction_counter = transaction_counter.clone();
+                let gas_price_counter = gas_price_counter.clone();
+                let priority_fee_counter = priority_fee_counter.clone();
                 tokio::spawn(async move {
                     let request = read_http_request(&mut stream).await;
                     let body = request
@@ -51,6 +59,14 @@ impl MockRpc {
                             transaction_counter.fetch_add(1, Ordering::SeqCst);
                             serde_json::Value::Null
                         }
+                        "eth_gasPrice" => {
+                            gas_price_counter.fetch_add(1, Ordering::SeqCst);
+                            serde_json::Value::String("0x64".to_string())
+                        }
+                        "eth_maxPriorityFeePerGas" => {
+                            priority_fee_counter.fetch_add(1, Ordering::SeqCst);
+                            serde_json::Value::String("0x2".to_string())
+                        }
                         _ => serde_json::Value::Null,
                     };
                     let response_body = serde_json::to_string(&serde_json::json!({
@@ -72,8 +88,25 @@ impl MockRpc {
             endpoint,
             receipt_calls,
             transaction_calls,
+            gas_price_calls,
+            priority_fee_calls,
         }
     }
+}
+
+#[tokio::test]
+async fn fee_suggestion_is_cached_within_one_head() {
+    let mock = MockRpc::start().await;
+    let client = BnsChainClient::new(&mock.endpoint);
+
+    let first = client.suggest_eip1559_fees().await.unwrap();
+    let second = client.suggest_eip1559_fees().await.unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(first.max_fee_per_gas, 202);
+    assert_eq!(first.max_priority_fee_per_gas, 2);
+    assert_eq!(mock.gas_price_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(mock.priority_fee_calls.load(Ordering::SeqCst), 1);
 }
 
 async fn read_http_request(stream: &mut TcpStream) -> String {

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -9,7 +9,7 @@ use bns_evm::{
     AuthorityKeyStatus as EvmAuthorityKeyStatus, AuthorityKeyUpdate as EvmAuthorityKeyUpdate,
     AuthoritySetState as EvmAuthoritySetState, BlockRange, Bns, BnsCall, BnsChainClient,
     ContractRead, DocumentRef as EvmDocumentRef, DocumentState as EvmDocumentState,
-    DocumentStatus as EvmDocumentStatus, EthBlock, EthLog, NameState as EvmNameState,
+    DocumentStatus as EvmDocumentStatus, EthBlock, NameState as EvmNameState,
     NameStatus as EvmNameStatus, OwnerSource as EvmOwnerSource, Principal as EvmPrincipal,
     PrincipalKind as EvmPrincipalKind, RpcLogFilter, B256,
 };
@@ -245,9 +245,8 @@ where
         };
         let logs = self.chain_client.get_logs(&filter).await?;
         let mut projector = ContractEventProjector::new();
-        let mut decoded_txs: HashMap<B256, Option<BnsCall>> = HashMap::new();
         let mut protocol_events_seen = 0;
-        let mut registry_events_stored = 0;
+        let mut registry_records = Vec::new();
 
         for log in logs.iter().filter(|log| !log.removed) {
             let observed_at = now_timestamp();
@@ -256,22 +255,29 @@ where
                     protocol_events_seen += 1;
                 }
                 ProjectedContractEvent::Registry(record) => {
-                    let decoded_call = if record_needs_decoded_call(&record) {
-                        self.decoded_call_for_log(log, &mut decoded_txs).await?
-                    } else {
-                        None
-                    };
-                    let projection = self
-                        .projection_for_record(&record, decoded_call.as_ref())
-                        .await?;
-                    self.store.transact(|tx| {
-                        tx.put_event_record(&record)?;
-                        projection.apply(tx)
-                    })?;
-                    registry_events_stored += 1;
+                    registry_records.push((record, log.transaction_hash));
                 }
                 ProjectedContractEvent::Router | ProjectedContractEvent::Infrastructure => {}
             }
+        }
+
+        let snapshot = self.load_projection_snapshot(&registry_records).await?;
+        let mut decoded_txs: HashMap<B256, Option<BnsCall>> = HashMap::new();
+        let mut registry_events_stored = 0;
+        for (record, transaction_hash) in registry_records {
+            let decoded_call = if record_needs_decoded_call(&record) {
+                self.decoded_call_for_hash(transaction_hash, &mut decoded_txs)
+                    .await?
+            } else {
+                None
+            };
+            let projection =
+                self.projection_for_record(&record, decoded_call.as_ref(), &snapshot)?;
+            self.store.transact(|tx| {
+                tx.put_event_record(&record)?;
+                projection.apply(tx)
+            })?;
+            registry_events_stored += 1;
         }
 
         let block_hash = self.block_hash_string(to_block, Some(&latest_head)).await?;
@@ -406,12 +412,12 @@ where
         })
     }
 
-    async fn decoded_call_for_log(
+    async fn decoded_call_for_hash(
         &self,
-        log: &EthLog,
+        tx_hash: Option<B256>,
         decoded_txs: &mut HashMap<B256, Option<BnsCall>>,
     ) -> BnsRegistryResult<Option<BnsCall>> {
-        let Some(tx_hash) = log.transaction_hash else {
+        let Some(tx_hash) = tx_hash else {
             return Ok(None);
         };
         if let Some(decoded) = decoded_txs.get(&tx_hash) {
@@ -426,7 +432,133 @@ where
         Ok(decoded)
     }
 
-    async fn projection_for_record(
+    async fn load_projection_snapshot(
+        &self,
+        records: &[(EventLogRecord, Option<B256>)],
+    ) -> BnsRegistryResult<ProjectionSnapshot> {
+        let mut seen = HashSet::new();
+        let mut reads = Vec::new();
+        for (record, _) in records {
+            for read in projection_reads_for_record(record) {
+                if seen.insert(read.clone()) {
+                    reads.push(read);
+                }
+            }
+        }
+        let calls = reads
+            .iter()
+            .map(|read| read.contract_read(self.contract))
+            .collect::<Vec<_>>();
+        let outputs = self.chain_client.multicall(&calls).await?;
+        if outputs.len() != reads.len() {
+            return Err(BnsRegistryError::InvalidConfig(format!(
+                "BNS projection batch returned {} values for {} reads",
+                outputs.len(),
+                reads.len()
+            )));
+        }
+        let mut snapshot = ProjectionSnapshot::default();
+        for (read, output) in reads.into_iter().zip(outputs) {
+            snapshot.insert(read, &output)?;
+        }
+        Ok(snapshot)
+    }
+
+    fn projection_for_record(
+        &self,
+        record: &EventLogRecord,
+        decoded_call: Option<&BnsCall>,
+        snapshot: &ProjectionSnapshot,
+    ) -> BnsRegistryResult<ContractProjectionWrite> {
+        snapshot.projection_for_record(record, decoded_call)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ProjectionReadKey {
+    Name(String),
+    Document(String, String, u64),
+    AuthoritySet(String),
+    Alias(String),
+    LatestCheckpoint,
+}
+
+impl ProjectionReadKey {
+    fn contract_read(&self, contract: Address) -> ContractRead {
+        match self {
+            Self::Name(name) => {
+                ContractRead::new(contract, &Bns::queryNameStateCall { name: name.clone() })
+            }
+            Self::Document(name, doc_type, version) => ContractRead::new(
+                contract,
+                &Bns::getDocumentVersionCall {
+                    name: name.clone(),
+                    docType: doc_type.clone(),
+                    version: *version,
+                },
+            ),
+            Self::AuthoritySet(name) => {
+                ContractRead::new(contract, &Bns::getAuthoritySetCall { name: name.clone() })
+            }
+            Self::Alias(name) => {
+                ContractRead::new(contract, &Bns::getAliasCall { name: name.clone() })
+            }
+            Self::LatestCheckpoint => ContractRead::new(contract, &Bns::latestCheckpointCall {}),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ProjectionSnapshot {
+    names: HashMap<String, Option<NameState>>,
+    documents: HashMap<(String, String, u64), Option<DocumentState>>,
+    authority_sets: HashMap<String, AuthoritySetState>,
+    aliases: HashMap<String, AliasState>,
+    checkpoint: Option<LogCheckpoint>,
+}
+
+impl ProjectionSnapshot {
+    fn insert(&mut self, read: ProjectionReadKey, output: &[u8]) -> BnsRegistryResult<()> {
+        match read {
+            ProjectionReadKey::Name(name) => {
+                let state = name_state_from_evm(
+                    decode_contract_return::<Bns::queryNameStateCall>(output)?,
+                )?;
+                self.names.insert(
+                    name,
+                    (state.status != NameStatus::Available).then_some(state),
+                );
+            }
+            ProjectionReadKey::Document(name, doc_type, version) => {
+                let state = document_state_from_evm(decode_contract_return::<
+                    Bns::getDocumentVersionCall,
+                >(output)?)?;
+                self.documents.insert(
+                    (name, doc_type, version),
+                    (state.status != DocumentStatus::Missing).then_some(state),
+                );
+            }
+            ProjectionReadKey::AuthoritySet(name) => {
+                let state = authority_set_from_evm(decode_contract_return::<
+                    Bns::getAuthoritySetCall,
+                >(output)?)?;
+                self.authority_sets.insert(name, state);
+            }
+            ProjectionReadKey::Alias(name) => {
+                let state =
+                    alias_state_from_evm(decode_contract_return::<Bns::getAliasCall>(output)?)?;
+                self.aliases.insert(name, state);
+            }
+            ProjectionReadKey::LatestCheckpoint => {
+                self.checkpoint = Some(checkpoint_from_evm(decode_contract_return::<
+                    Bns::latestCheckpointCall,
+                >(output)?)?);
+            }
+        }
+        Ok(())
+    }
+
+    fn projection_for_record(
         &self,
         record: &EventLogRecord,
         decoded_call: Option<&BnsCall>,
@@ -440,7 +572,7 @@ where
             | RegistryEvent::NameReleased { name, .. }
             | RegistryEvent::OwnerDocumentIatFloorUpdated { name, .. }
             | RegistryEvent::NamespacePolicyUpdated { name, .. } => {
-                self.push_name_state(&mut write, name).await?;
+                self.push_name(&mut write, name)?;
             }
             RegistryEvent::DocumentPublished {
                 name,
@@ -448,8 +580,8 @@ where
                 version,
                 ..
             } => {
-                self.push_name_and_document_state(&mut write, name, doc_type, *version)
-                    .await?;
+                self.push_name(&mut write, name)?;
+                self.push_document(&mut write, name, doc_type, *version)?;
             }
             RegistryEvent::DocumentRevoked {
                 name,
@@ -457,11 +589,14 @@ where
                 new_version,
                 ..
             } => {
-                self.push_name_and_document_state(&mut write, name, doc_type, *new_version)
-                    .await?;
+                self.push_name(&mut write, name)?;
+                self.push_document(&mut write, name, doc_type, *new_version)?;
             }
             RegistryEvent::AuthorityKeysUpdated { name, .. } => {
-                let set = self.read_authority_set(name).await?;
+                let set =
+                    self.authority_sets.get(name).cloned().ok_or_else(|| {
+                        missing_projection_read(format!("authority set for {name}"))
+                    })?;
                 write.authority_sets.push(set);
                 for key in authority_keys_from_call(decoded_call, name)? {
                     write.authority_keys.push((canonical_bns_name(name)?, key));
@@ -470,7 +605,7 @@ where
             RegistryEvent::ControllerPolicyUpdated {
                 name, policy_hash, ..
             } => {
-                self.push_name_state(&mut write, name).await?;
+                self.push_name(&mut write, name)?;
                 if let Some(rules) = controller_rules_from_call(decoded_call, name)? {
                     write.controller_policies.push((
                         canonical_bns_name(name)?,
@@ -480,7 +615,13 @@ where
                 }
             }
             RegistryEvent::DidAliasSet { name, .. } => {
-                self.push_name_and_alias_state(&mut write, name).await?;
+                self.push_name(&mut write, name)?;
+                write.aliases.push(
+                    self.aliases
+                        .get(name)
+                        .cloned()
+                        .ok_or_else(|| missing_projection_read(format!("alias for {name}")))?,
+                );
             }
             RegistryEvent::PaymentTargetUpdated {
                 name,
@@ -488,136 +629,102 @@ where
                 version,
                 ..
             } => {
-                self.push_name_and_document_state(&mut write, name, doc_type, *version)
-                    .await?;
+                self.push_name(&mut write, name)?;
+                self.push_document(&mut write, name, doc_type, *version)?;
             }
             RegistryEvent::LogCheckpointPublished { .. } => {
-                write.checkpoints.push(self.read_latest_checkpoint().await?);
+                write.checkpoints.push(
+                    self.checkpoint
+                        .clone()
+                        .ok_or_else(|| missing_projection_read("latest checkpoint"))?,
+                );
             }
         }
         Ok(write)
     }
 
-    async fn push_name_state(
-        &self,
-        write: &mut ContractProjectionWrite,
-        name: &str,
-    ) -> BnsRegistryResult<()> {
-        if let Some(state) = self.read_name_state(name).await? {
-            write.names.push(state);
+    fn push_name(&self, write: &mut ContractProjectionWrite, name: &str) -> BnsRegistryResult<()> {
+        let state = self
+            .names
+            .get(name)
+            .ok_or_else(|| missing_projection_read(format!("name state for {name}")))?;
+        if let Some(state) = state {
+            write.names.push(state.clone());
         }
         Ok(())
     }
 
-    async fn push_name_and_document_state(
+    fn push_document(
         &self,
         write: &mut ContractProjectionWrite,
         name: &str,
         doc_type: &str,
         version: u64,
     ) -> BnsRegistryResult<()> {
-        let name_call = Bns::queryNameStateCall {
-            name: name.to_string(),
-        };
-        let document_call = Bns::getDocumentVersionCall {
-            name: name.to_string(),
-            docType: doc_type.to_string(),
+        let state = self
+            .documents
+            .get(&(name.to_string(), doc_type.to_string(), version))
+            .ok_or_else(|| {
+                missing_projection_read(format!("document {name}/{doc_type}/{version}"))
+            })?;
+        if let Some(state) = state {
+            write.documents.push(state.clone());
+        }
+        Ok(())
+    }
+}
+
+fn projection_reads_for_record(record: &EventLogRecord) -> Vec<ProjectionReadKey> {
+    match &record.event {
+        RegistryEvent::NameRegistered { name, .. }
+        | RegistryEvent::NameRenewed { name, .. }
+        | RegistryEvent::NameAssetTransferred { name, .. }
+        | RegistryEvent::NameOwnerUpdated { name, .. }
+        | RegistryEvent::NameReleased { name, .. }
+        | RegistryEvent::OwnerDocumentIatFloorUpdated { name, .. }
+        | RegistryEvent::NamespacePolicyUpdated { name, .. }
+        | RegistryEvent::ControllerPolicyUpdated { name, .. } => {
+            vec![ProjectionReadKey::Name(name.clone())]
+        }
+        RegistryEvent::DocumentPublished {
+            name,
+            doc_type,
             version,
-        };
-        let outputs = self
-            .chain_client
-            .multicall(&[
-                ContractRead::new(self.contract, &name_call),
-                ContractRead::new(self.contract, &document_call),
-            ])
-            .await?;
-
-        let name_state = name_state_from_evm(decode_contract_return::<Bns::queryNameStateCall>(
-            &outputs[0],
-        )?)?;
-        if name_state.status != NameStatus::Available {
-            write.names.push(name_state);
+            ..
         }
-        let document_state = document_state_from_evm(decode_contract_return::<
-            Bns::getDocumentVersionCall,
-        >(&outputs[1])?)?;
-        if document_state.status != DocumentStatus::Missing {
-            write.documents.push(document_state);
+        | RegistryEvent::PaymentTargetUpdated {
+            name,
+            doc_type,
+            version,
+            ..
+        } => vec![
+            ProjectionReadKey::Name(name.clone()),
+            ProjectionReadKey::Document(name.clone(), doc_type.clone(), *version),
+        ],
+        RegistryEvent::DocumentRevoked {
+            name,
+            doc_type,
+            new_version,
+            ..
+        } => vec![
+            ProjectionReadKey::Name(name.clone()),
+            ProjectionReadKey::Document(name.clone(), doc_type.clone(), *new_version),
+        ],
+        RegistryEvent::AuthorityKeysUpdated { name, .. } => {
+            vec![ProjectionReadKey::AuthoritySet(name.clone())]
         }
-        Ok(())
-    }
-
-    async fn push_name_and_alias_state(
-        &self,
-        write: &mut ContractProjectionWrite,
-        name: &str,
-    ) -> BnsRegistryResult<()> {
-        let name_call = Bns::queryNameStateCall {
-            name: name.to_string(),
-        };
-        let alias_call = Bns::getAliasCall {
-            name: name.to_string(),
-        };
-        let outputs = self
-            .chain_client
-            .multicall(&[
-                ContractRead::new(self.contract, &name_call),
-                ContractRead::new(self.contract, &alias_call),
-            ])
-            .await?;
-
-        let name_state = name_state_from_evm(decode_contract_return::<Bns::queryNameStateCall>(
-            &outputs[0],
-        )?)?;
-        if name_state.status != NameStatus::Available {
-            write.names.push(name_state);
-        }
-        write
-            .aliases
-            .push(alias_state_from_evm(decode_contract_return::<
-                Bns::getAliasCall,
-            >(&outputs[1])?)?);
-        Ok(())
-    }
-
-    async fn read_name_state(&self, name: &str) -> BnsRegistryResult<Option<NameState>> {
-        let state = self
-            .chain_client
-            .call_contract(
-                self.contract,
-                &Bns::queryNameStateCall {
-                    name: name.to_string(),
-                },
-            )
-            .await?;
-        let state = name_state_from_evm(state)?;
-        if state.status == NameStatus::Available {
-            Ok(None)
-        } else {
-            Ok(Some(state))
+        RegistryEvent::DidAliasSet { name, .. } => vec![
+            ProjectionReadKey::Name(name.clone()),
+            ProjectionReadKey::Alias(name.clone()),
+        ],
+        RegistryEvent::LogCheckpointPublished { .. } => {
+            vec![ProjectionReadKey::LatestCheckpoint]
         }
     }
+}
 
-    async fn read_authority_set(&self, name: &str) -> BnsRegistryResult<AuthoritySetState> {
-        let state = self
-            .chain_client
-            .call_contract(
-                self.contract,
-                &Bns::getAuthoritySetCall {
-                    name: name.to_string(),
-                },
-            )
-            .await?;
-        authority_set_from_evm(state)
-    }
-
-    async fn read_latest_checkpoint(&self) -> BnsRegistryResult<LogCheckpoint> {
-        let checkpoint = self
-            .chain_client
-            .call_contract(self.contract, &Bns::latestCheckpointCall {})
-            .await?;
-        checkpoint_from_evm(checkpoint)
-    }
+fn missing_projection_read(detail: impl Into<String>) -> BnsRegistryError {
+    BnsRegistryError::InvalidConfig(format!("BNS projection batch is missing {}", detail.into()))
 }
 
 fn record_needs_decoded_call(record: &EventLogRecord) -> bool {

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -155,6 +155,21 @@ where
     ) -> BnsRegistryResult<Self> {
         config.validate()?;
         let contract = config.source.contract_address()?;
+        if let Some(configured_contract) = chain_client.contract_address() {
+            if configured_contract != contract {
+                return Err(BnsRegistryError::InvalidConfig(format!(
+                    "BNS chain client contract {configured_contract:#x} does not match indexer contract {contract:#x}"
+                )));
+            }
+        }
+        if let Some(configured_chain_id) = chain_client.configured_chain_id() {
+            if configured_chain_id != config.source.chain_id {
+                return Err(BnsRegistryError::InvalidConfig(format!(
+                    "BNS chain client chain_id {configured_chain_id} does not match indexer chain_id {}",
+                    config.source.chain_id
+                )));
+            }
+        }
         let source = config.source.source_id()?;
         Ok(Self {
             store,

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -23,6 +23,8 @@ use crate::{
     ProjectedContractEvent, RegistryEvent, ZERO_HASH,
 };
 
+const CHAIN_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BnsBlockSyncSourceConfig {
     pub network: String,
@@ -286,8 +288,10 @@ where
             interval
         };
         loop {
-            on_sync(self.sync_once().await);
-            tokio::time::sleep(interval).await;
+            let outcome = self.sync_once().await;
+            let delay = polling_delay(interval, outcome.is_err());
+            on_sync(outcome);
+            tokio::time::sleep(delay).await;
         }
     }
 
@@ -564,6 +568,31 @@ where
             .call_contract(self.contract, &Bns::latestCheckpointCall {})
             .await?;
         checkpoint_from_evm(checkpoint)
+    }
+}
+
+fn polling_delay(idle_interval: Duration, failed: bool) -> Duration {
+    if failed {
+        CHAIN_ERROR_RETRY_INTERVAL
+    } else {
+        idle_interval
+    }
+}
+
+#[cfg(test)]
+mod polling_tests {
+    use super::*;
+
+    #[test]
+    fn chain_errors_use_fixed_retry_delay() {
+        assert_eq!(
+            polling_delay(Duration::from_secs(15), true),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            polling_delay(Duration::from_secs(15), false),
+            Duration::from_secs(15)
+        );
     }
 }
 

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -1,15 +1,16 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use bns_evm::{
     decode_bns_call, Address, AliasKind as EvmAliasKind, AliasState as EvmAliasState,
     AuthorityKey as EvmAuthorityKey, AuthorityKeyStatus as EvmAuthorityKeyStatus,
     AuthorityKeyUpdate as EvmAuthorityKeyUpdate, AuthoritySetState as EvmAuthoritySetState,
-    BlockRange, Bns, BnsCall, DocumentRef as EvmDocumentRef, DocumentState as EvmDocumentState,
-    DocumentStatus as EvmDocumentStatus, EthLog, EthRpcClient, NameState as EvmNameState,
-    NameStatus as EvmNameStatus, OwnerSource as EvmOwnerSource, Principal as EvmPrincipal,
-    PrincipalKind as EvmPrincipalKind, RpcLogFilter, B256,
+    BlockRange, Bns, BnsCall, BnsChainClient, DocumentRef as EvmDocumentRef,
+    DocumentState as EvmDocumentState, DocumentStatus as EvmDocumentStatus, EthLog,
+    NameState as EvmNameState, NameStatus as EvmNameStatus, OwnerSource as EvmOwnerSource,
+    Principal as EvmPrincipal, PrincipalKind as EvmPrincipalKind, RpcLogFilter, B256,
 };
 use serde::{Deserialize, Serialize};
 
@@ -132,7 +133,7 @@ where
 {
     store: &'a S,
     config: BnsIndexerSyncConfig,
-    rpc: EthRpcClient,
+    chain_client: Arc<BnsChainClient>,
     contract: Address,
     source: String,
 }
@@ -142,14 +143,22 @@ where
     S: BnsRegistryStore,
 {
     pub fn new(store: &'a S, config: BnsIndexerSyncConfig) -> BnsRegistryResult<Self> {
+        let chain_client = Arc::new(BnsChainClient::new(config.source.rpc_endpoint.clone()));
+        Self::new_with_chain_client(store, config, chain_client)
+    }
+
+    pub fn new_with_chain_client(
+        store: &'a S,
+        config: BnsIndexerSyncConfig,
+        chain_client: Arc<BnsChainClient>,
+    ) -> BnsRegistryResult<Self> {
         config.validate()?;
         let contract = config.source.contract_address()?;
         let source = config.source.source_id()?;
-        let rpc = EthRpcClient::new(config.source.rpc_endpoint.clone());
         Ok(Self {
             store,
             config,
-            rpc,
+            chain_client,
             contract,
             source,
         })
@@ -164,7 +173,7 @@ where
     }
 
     pub async fn sync_once(&self) -> BnsRegistryResult<BnsIndexerSyncOutcome> {
-        let remote_chain_id = self.rpc.chain_id().await?;
+        let remote_chain_id = self.chain_client.chain_id().await?;
         if remote_chain_id != self.config.source.chain_id {
             return Err(BnsRegistryError::InvalidConfig(format!(
                 "BNS indexer configured for chain_id {}, but RPC {} returned chain_id {}",
@@ -172,7 +181,7 @@ where
             )));
         }
 
-        let latest_block = self.rpc.block_number().await?;
+        let latest_block = self.chain_client.block_number().await?;
         let reorg_detected = self.reset_projection_if_reorged(latest_block).await?;
         let target_block = latest_block.saturating_sub(self.config.confirmations);
         let from_block = self.next_block_to_sync()?;
@@ -199,7 +208,7 @@ where
             to_block: BlockRange::Number(to_block),
             topics: Vec::new(),
         };
-        let logs = self.rpc.get_logs(&filter).await?;
+        let logs = self.chain_client.get_logs(&filter).await?;
         let mut projector = ContractEventProjector::new();
         let mut decoded_txs: HashMap<B256, Option<BnsCall>> = HashMap::new();
         let mut protocol_events_seen = 0;
@@ -304,7 +313,7 @@ where
 
     async fn block_hash_string(&self, block_number: u64) -> BnsRegistryResult<String> {
         let block = self
-            .rpc
+            .chain_client
             .block_by_number(block_number)
             .await?
             .ok_or_else(|| {
@@ -340,7 +349,7 @@ where
             return Ok(decoded.clone());
         }
 
-        let decoded = match self.rpc.transaction_by_hash(tx_hash).await? {
+        let decoded = match self.chain_client.transaction_by_hash(tx_hash).await? {
             Some(tx) => Some(decode_bns_call(&tx.input)?),
             None => None,
         };
@@ -451,7 +460,7 @@ where
 
     async fn read_name_state(&self, name: &str) -> BnsRegistryResult<Option<NameState>> {
         let state = self
-            .rpc
+            .chain_client
             .call_contract(
                 self.contract,
                 &Bns::queryNameStateCall {
@@ -474,7 +483,7 @@ where
         version: u64,
     ) -> BnsRegistryResult<Option<DocumentState>> {
         let state = self
-            .rpc
+            .chain_client
             .call_contract(
                 self.contract,
                 &Bns::getDocumentVersionCall {
@@ -494,7 +503,7 @@ where
 
     async fn read_authority_set(&self, name: &str) -> BnsRegistryResult<AuthoritySetState> {
         let state = self
-            .rpc
+            .chain_client
             .call_contract(
                 self.contract,
                 &Bns::getAuthoritySetCall {
@@ -507,7 +516,7 @@ where
 
     async fn read_alias(&self, name: &str) -> BnsRegistryResult<AliasState> {
         let state = self
-            .rpc
+            .chain_client
             .call_contract(
                 self.contract,
                 &Bns::getAliasCall {
@@ -520,7 +529,7 @@ where
 
     async fn read_latest_checkpoint(&self) -> BnsRegistryResult<LogCheckpoint> {
         let checkpoint = self
-            .rpc
+            .chain_client
             .call_contract(self.contract, &Bns::latestCheckpointCall {})
             .await?;
         checkpoint_from_evm(checkpoint)

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -256,7 +256,11 @@ where
                     protocol_events_seen += 1;
                 }
                 ProjectedContractEvent::Registry(record) => {
-                    let decoded_call = self.decoded_call_for_log(log, &mut decoded_txs).await?;
+                    let decoded_call = if record_needs_decoded_call(&record) {
+                        self.decoded_call_for_log(log, &mut decoded_txs).await?
+                    } else {
+                        None
+                    };
                     let projection = self
                         .projection_for_record(&record, decoded_call.as_ref())
                         .await?;
@@ -613,6 +617,13 @@ where
             .await?;
         checkpoint_from_evm(checkpoint)
     }
+}
+
+fn record_needs_decoded_call(record: &EventLogRecord) -> bool {
+    matches!(
+        &record.event,
+        RegistryEvent::AuthorityKeysUpdated { .. } | RegistryEvent::ControllerPolicyUpdated { .. }
+    )
 }
 
 fn polling_delay(idle_interval: Duration, failed: bool, has_backlog: bool) -> Duration {

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -9,7 +9,7 @@ use bns_evm::{
     AuthorityKeyStatus as EvmAuthorityKeyStatus, AuthorityKeyUpdate as EvmAuthorityKeyUpdate,
     AuthoritySetState as EvmAuthoritySetState, BlockRange, Bns, BnsCall, BnsChainClient,
     ContractRead, DocumentRef as EvmDocumentRef, DocumentState as EvmDocumentState,
-    DocumentStatus as EvmDocumentStatus, EthLog, NameState as EvmNameState,
+    DocumentStatus as EvmDocumentStatus, EthBlock, EthLog, NameState as EvmNameState,
     NameStatus as EvmNameStatus, OwnerSource as EvmOwnerSource, Principal as EvmPrincipal,
     PrincipalKind as EvmPrincipalKind, RpcLogFilter, B256,
 };
@@ -191,6 +191,13 @@ where
     }
 
     pub async fn sync_once(&self) -> BnsRegistryResult<BnsIndexerSyncOutcome> {
+        self.sync_once_with_head_refresh(true).await
+    }
+
+    async fn sync_once_with_head_refresh(
+        &self,
+        refresh_head: bool,
+    ) -> BnsRegistryResult<BnsIndexerSyncOutcome> {
         let remote_chain_id = self.chain_client.chain_id().await?;
         if remote_chain_id != self.config.source.chain_id {
             return Err(BnsRegistryError::InvalidConfig(format!(
@@ -199,8 +206,18 @@ where
             )));
         }
 
-        let latest_block = self.chain_client.block_number().await?;
-        let reorg_detected = self.reset_projection_if_reorged(latest_block).await?;
+        let (latest_head, head_changed) = self.chain_client.latest_block(refresh_head).await?;
+        let latest_block = latest_head.number.ok_or_else(|| {
+            BnsRegistryError::InvalidConfig(format!(
+                "BNS indexer latest block from RPC {} has no number",
+                self.config.source.rpc_endpoint
+            ))
+        })?;
+        let reorg_detected = if head_changed {
+            self.reset_projection_if_reorged(&latest_head).await?
+        } else {
+            false
+        };
         let target_block = latest_block.saturating_sub(self.config.confirmations);
         let from_block = self.next_block_to_sync()?;
         if from_block > target_block {
@@ -253,7 +270,7 @@ where
             }
         }
 
-        let block_hash = self.block_hash_string(to_block).await?;
+        let block_hash = self.block_hash_string(to_block, Some(&latest_head)).await?;
         let cursor = IndexerCursor {
             source: self.source.clone(),
             block_number: to_block,
@@ -287,8 +304,9 @@ where
         } else {
             interval
         };
+        let mut refresh_head = true;
         loop {
-            let outcome = self.sync_once().await;
+            let outcome = self.sync_once_with_head_refresh(refresh_head).await;
             let has_backlog = outcome.as_ref().is_ok_and(|outcome| {
                 outcome.to_block.is_some_and(|to_block| {
                     to_block
@@ -299,6 +317,7 @@ where
             });
             let delay = polling_delay(interval, outcome.is_err(), has_backlog);
             on_sync(outcome);
+            refresh_head = !has_backlog;
             if !delay.is_zero() {
                 tokio::time::sleep(delay).await;
             }
@@ -318,17 +337,25 @@ where
             .transact(|tx| tx.get_indexer_cursor(&self.source))
     }
 
-    async fn reset_projection_if_reorged(&self, latest_block: u64) -> BnsRegistryResult<bool> {
+    async fn reset_projection_if_reorged(&self, latest_head: &EthBlock) -> BnsRegistryResult<bool> {
         let Some(mut cursor) = self.cursor()? else {
             return Ok(false);
         };
+        let latest_block = latest_head.number.ok_or_else(|| {
+            BnsRegistryError::InvalidConfig("BNS latest block has no number".to_string())
+        })?;
 
         let should_reset = if cursor.block_number > latest_block {
             true
         } else if let Some(expected_hash) = cursor.block_hash.as_deref() {
-            self.block_hash_string(cursor.block_number).await? != expected_hash
+            self.block_hash_string(cursor.block_number, Some(latest_head))
+                .await?
+                != expected_hash
         } else {
-            cursor.block_hash = Some(self.block_hash_string(cursor.block_number).await?);
+            cursor.block_hash = Some(
+                self.block_hash_string(cursor.block_number, Some(latest_head))
+                    .await?,
+            );
             cursor.updated_at = now_timestamp();
             self.store.transact(|tx| tx.put_indexer_cursor(&cursor))?;
             false
@@ -341,17 +368,24 @@ where
         Ok(should_reset)
     }
 
-    async fn block_hash_string(&self, block_number: u64) -> BnsRegistryResult<String> {
-        let block = self
-            .chain_client
-            .block_by_number(block_number)
-            .await?
-            .ok_or_else(|| {
-                BnsRegistryError::InvalidConfig(format!(
-                    "BNS indexer cannot read block {block_number} from RPC {}",
-                    self.config.source.rpc_endpoint
-                ))
-            })?;
+    async fn block_hash_string(
+        &self,
+        block_number: u64,
+        latest_head: Option<&EthBlock>,
+    ) -> BnsRegistryResult<String> {
+        let block = if latest_head.is_some_and(|head| head.number == Some(block_number)) {
+            latest_head.cloned().unwrap()
+        } else {
+            self.chain_client
+                .block_by_number(block_number)
+                .await?
+                .ok_or_else(|| {
+                    BnsRegistryError::InvalidConfig(format!(
+                        "BNS indexer cannot read block {block_number} from RPC {}",
+                        self.config.source.rpc_endpoint
+                    ))
+                })?
+        };
         if let Some(actual_number) = block.number {
             if actual_number != block_number {
                 return Err(BnsRegistryError::InvalidConfig(format!(

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -100,7 +100,7 @@ impl BnsIndexerSyncConfig {
         Self {
             source,
             confirmations: 0,
-            max_block_span: 1_000,
+            max_block_span: 500,
         }
     }
 
@@ -289,9 +289,19 @@ where
         };
         loop {
             let outcome = self.sync_once().await;
-            let delay = polling_delay(interval, outcome.is_err());
+            let has_backlog = outcome.as_ref().is_ok_and(|outcome| {
+                outcome.to_block.is_some_and(|to_block| {
+                    to_block
+                        < outcome
+                            .latest_block
+                            .saturating_sub(self.config.confirmations)
+                })
+            });
+            let delay = polling_delay(interval, outcome.is_err(), has_backlog);
             on_sync(outcome);
-            tokio::time::sleep(delay).await;
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
         }
     }
 
@@ -571,9 +581,11 @@ where
     }
 }
 
-fn polling_delay(idle_interval: Duration, failed: bool) -> Duration {
+fn polling_delay(idle_interval: Duration, failed: bool, has_backlog: bool) -> Duration {
     if failed {
         CHAIN_ERROR_RETRY_INTERVAL
+    } else if has_backlog {
+        Duration::ZERO
     } else {
         idle_interval
     }
@@ -586,12 +598,16 @@ mod polling_tests {
     #[test]
     fn chain_errors_use_fixed_retry_delay() {
         assert_eq!(
-            polling_delay(Duration::from_secs(15), true),
+            polling_delay(Duration::from_secs(15), true, true),
             Duration::from_secs(30)
         );
         assert_eq!(
-            polling_delay(Duration::from_secs(15), false),
+            polling_delay(Duration::from_secs(15), false, false),
             Duration::from_secs(15)
+        );
+        assert_eq!(
+            polling_delay(Duration::from_secs(15), false, true),
+            Duration::ZERO
         );
     }
 }

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -4,13 +4,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bns_evm::{
-    decode_bns_call, Address, AliasKind as EvmAliasKind, AliasState as EvmAliasState,
-    AuthorityKey as EvmAuthorityKey, AuthorityKeyStatus as EvmAuthorityKeyStatus,
-    AuthorityKeyUpdate as EvmAuthorityKeyUpdate, AuthoritySetState as EvmAuthoritySetState,
-    BlockRange, Bns, BnsCall, BnsChainClient, DocumentRef as EvmDocumentRef,
-    DocumentState as EvmDocumentState, DocumentStatus as EvmDocumentStatus, EthLog,
-    NameState as EvmNameState, NameStatus as EvmNameStatus, OwnerSource as EvmOwnerSource,
-    Principal as EvmPrincipal, PrincipalKind as EvmPrincipalKind, RpcLogFilter, B256,
+    decode_bns_call, decode_contract_return, Address, AliasKind as EvmAliasKind,
+    AliasState as EvmAliasState, AuthorityKey as EvmAuthorityKey,
+    AuthorityKeyStatus as EvmAuthorityKeyStatus, AuthorityKeyUpdate as EvmAuthorityKeyUpdate,
+    AuthoritySetState as EvmAuthoritySetState, BlockRange, Bns, BnsCall, BnsChainClient,
+    ContractRead, DocumentRef as EvmDocumentRef, DocumentState as EvmDocumentState,
+    DocumentStatus as EvmDocumentStatus, EthLog, NameState as EvmNameState,
+    NameStatus as EvmNameStatus, OwnerSource as EvmOwnerSource, Principal as EvmPrincipal,
+    PrincipalKind as EvmPrincipalKind, RpcLogFilter, B256,
 };
 use serde::{Deserialize, Serialize};
 
@@ -379,8 +380,7 @@ where
                 version,
                 ..
             } => {
-                self.push_name_state(&mut write, name).await?;
-                self.push_document_state(&mut write, name, doc_type, *version)
+                self.push_name_and_document_state(&mut write, name, doc_type, *version)
                     .await?;
             }
             RegistryEvent::DocumentRevoked {
@@ -389,8 +389,7 @@ where
                 new_version,
                 ..
             } => {
-                self.push_name_state(&mut write, name).await?;
-                self.push_document_state(&mut write, name, doc_type, *new_version)
+                self.push_name_and_document_state(&mut write, name, doc_type, *new_version)
                     .await?;
             }
             RegistryEvent::AuthorityKeysUpdated { name, .. } => {
@@ -413,9 +412,7 @@ where
                 }
             }
             RegistryEvent::DidAliasSet { name, .. } => {
-                self.push_name_state(&mut write, name).await?;
-                let alias = self.read_alias(name).await?;
-                write.aliases.push(alias);
+                self.push_name_and_alias_state(&mut write, name).await?;
             }
             RegistryEvent::PaymentTargetUpdated {
                 name,
@@ -423,8 +420,7 @@ where
                 version,
                 ..
             } => {
-                self.push_name_state(&mut write, name).await?;
-                self.push_document_state(&mut write, name, doc_type, *version)
+                self.push_name_and_document_state(&mut write, name, doc_type, *version)
                     .await?;
             }
             RegistryEvent::LogCheckpointPublished { .. } => {
@@ -445,16 +441,74 @@ where
         Ok(())
     }
 
-    async fn push_document_state(
+    async fn push_name_and_document_state(
         &self,
         write: &mut ContractProjectionWrite,
         name: &str,
         doc_type: &str,
         version: u64,
     ) -> BnsRegistryResult<()> {
-        if let Some(state) = self.read_document_state(name, doc_type, version).await? {
-            write.documents.push(state);
+        let name_call = Bns::queryNameStateCall {
+            name: name.to_string(),
+        };
+        let document_call = Bns::getDocumentVersionCall {
+            name: name.to_string(),
+            docType: doc_type.to_string(),
+            version,
+        };
+        let outputs = self
+            .chain_client
+            .multicall(&[
+                ContractRead::new(self.contract, &name_call),
+                ContractRead::new(self.contract, &document_call),
+            ])
+            .await?;
+
+        let name_state = name_state_from_evm(decode_contract_return::<Bns::queryNameStateCall>(
+            &outputs[0],
+        )?)?;
+        if name_state.status != NameStatus::Available {
+            write.names.push(name_state);
         }
+        let document_state = document_state_from_evm(decode_contract_return::<
+            Bns::getDocumentVersionCall,
+        >(&outputs[1])?)?;
+        if document_state.status != DocumentStatus::Missing {
+            write.documents.push(document_state);
+        }
+        Ok(())
+    }
+
+    async fn push_name_and_alias_state(
+        &self,
+        write: &mut ContractProjectionWrite,
+        name: &str,
+    ) -> BnsRegistryResult<()> {
+        let name_call = Bns::queryNameStateCall {
+            name: name.to_string(),
+        };
+        let alias_call = Bns::getAliasCall {
+            name: name.to_string(),
+        };
+        let outputs = self
+            .chain_client
+            .multicall(&[
+                ContractRead::new(self.contract, &name_call),
+                ContractRead::new(self.contract, &alias_call),
+            ])
+            .await?;
+
+        let name_state = name_state_from_evm(decode_contract_return::<Bns::queryNameStateCall>(
+            &outputs[0],
+        )?)?;
+        if name_state.status != NameStatus::Available {
+            write.names.push(name_state);
+        }
+        write
+            .aliases
+            .push(alias_state_from_evm(decode_contract_return::<
+                Bns::getAliasCall,
+            >(&outputs[1])?)?);
         Ok(())
     }
 
@@ -476,31 +530,6 @@ where
         }
     }
 
-    async fn read_document_state(
-        &self,
-        name: &str,
-        doc_type: &str,
-        version: u64,
-    ) -> BnsRegistryResult<Option<DocumentState>> {
-        let state = self
-            .chain_client
-            .call_contract(
-                self.contract,
-                &Bns::getDocumentVersionCall {
-                    name: name.to_string(),
-                    docType: doc_type.to_string(),
-                    version,
-                },
-            )
-            .await?;
-        let state = document_state_from_evm(state)?;
-        if state.status == DocumentStatus::Missing {
-            Ok(None)
-        } else {
-            Ok(Some(state))
-        }
-    }
-
     async fn read_authority_set(&self, name: &str) -> BnsRegistryResult<AuthoritySetState> {
         let state = self
             .chain_client
@@ -512,19 +541,6 @@ where
             )
             .await?;
         authority_set_from_evm(state)
-    }
-
-    async fn read_alias(&self, name: &str) -> BnsRegistryResult<AliasState> {
-        let state = self
-            .chain_client
-            .call_contract(
-                self.contract,
-                &Bns::getAliasCall {
-                    name: name.to_string(),
-                },
-            )
-            .await?;
-        alias_state_from_evm(state)
     }
 
     async fn read_latest_checkpoint(&self) -> BnsRegistryResult<LogCheckpoint> {

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -261,9 +261,8 @@ where
             }
         }
 
-        let snapshot = self.load_projection_snapshot(&registry_records).await?;
         let mut decoded_txs: HashMap<B256, Option<BnsCall>> = HashMap::new();
-        let mut registry_events_stored = 0;
+        let mut projection_records = Vec::with_capacity(registry_records.len());
         for (record, transaction_hash) in registry_records {
             let decoded_call = if record_needs_decoded_call(&record) {
                 self.decoded_call_for_hash(transaction_hash, &mut decoded_txs)
@@ -271,6 +270,12 @@ where
             } else {
                 None
             };
+            projection_records.push((record, decoded_call));
+        }
+
+        let snapshot = self.load_projection_snapshot(&projection_records).await?;
+        let mut registry_events_stored = 0;
+        for (record, decoded_call) in projection_records {
             let projection =
                 self.projection_for_record(&record, decoded_call.as_ref(), &snapshot)?;
             self.store.transact(|tx| {
@@ -434,12 +439,12 @@ where
 
     async fn load_projection_snapshot(
         &self,
-        records: &[(EventLogRecord, Option<B256>)],
+        records: &[(EventLogRecord, Option<BnsCall>)],
     ) -> BnsRegistryResult<ProjectionSnapshot> {
         let mut seen = HashSet::new();
         let mut reads = Vec::new();
-        for (record, _) in records {
-            for read in projection_reads_for_record(record) {
+        for (record, decoded_call) in records {
+            for read in projection_reads_for_record(record, decoded_call.as_ref()) {
                 if seen.insert(read.clone()) {
                     reads.push(read);
                 }
@@ -633,11 +638,15 @@ impl ProjectionSnapshot {
                 self.push_document(&mut write, name, doc_type, *version)?;
             }
             RegistryEvent::LogCheckpointPublished { .. } => {
-                write.checkpoints.push(
-                    self.checkpoint
-                        .clone()
-                        .ok_or_else(|| missing_projection_read("latest checkpoint"))?,
-                );
+                if let Some(checkpoint) = checkpoint_from_event_and_call(record, decoded_call)? {
+                    write.checkpoints.push(checkpoint);
+                } else {
+                    write.checkpoints.push(
+                        self.checkpoint
+                            .clone()
+                            .ok_or_else(|| missing_projection_read("latest checkpoint"))?,
+                    );
+                }
             }
         }
         Ok(write)
@@ -674,7 +683,10 @@ impl ProjectionSnapshot {
     }
 }
 
-fn projection_reads_for_record(record: &EventLogRecord) -> Vec<ProjectionReadKey> {
+fn projection_reads_for_record(
+    record: &EventLogRecord,
+    decoded_call: Option<&BnsCall>,
+) -> Vec<ProjectionReadKey> {
     match &record.event {
         RegistryEvent::NameRegistered { name, .. }
         | RegistryEvent::NameRenewed { name, .. }
@@ -717,9 +729,12 @@ fn projection_reads_for_record(record: &EventLogRecord) -> Vec<ProjectionReadKey
             ProjectionReadKey::Name(name.clone()),
             ProjectionReadKey::Alias(name.clone()),
         ],
-        RegistryEvent::LogCheckpointPublished { .. } => {
-            vec![ProjectionReadKey::LatestCheckpoint]
+        RegistryEvent::LogCheckpointPublished { .. }
+            if matches!(decoded_call, Some(BnsCall::publishLogCheckpoint(_))) =>
+        {
+            Vec::new()
         }
+        RegistryEvent::LogCheckpointPublished { .. } => vec![ProjectionReadKey::LatestCheckpoint],
     }
 }
 
@@ -730,8 +745,41 @@ fn missing_projection_read(detail: impl Into<String>) -> BnsRegistryError {
 fn record_needs_decoded_call(record: &EventLogRecord) -> bool {
     matches!(
         &record.event,
-        RegistryEvent::AuthorityKeysUpdated { .. } | RegistryEvent::ControllerPolicyUpdated { .. }
+        RegistryEvent::AuthorityKeysUpdated { .. }
+            | RegistryEvent::ControllerPolicyUpdated { .. }
+            | RegistryEvent::LogCheckpointPublished { .. }
     )
+}
+
+fn checkpoint_from_event_and_call(
+    record: &EventLogRecord,
+    decoded_call: Option<&BnsCall>,
+) -> BnsRegistryResult<Option<LogCheckpoint>> {
+    let RegistryEvent::LogCheckpointPublished {
+        log_root,
+        last_seq,
+        issued_at,
+        external_anchor,
+    } = &record.event
+    else {
+        return Ok(None);
+    };
+    let Some(BnsCall::publishLogCheckpoint(call)) = decoded_call else {
+        return Ok(None);
+    };
+    let call_anchor = hash_string(call.externalAnchor);
+    if call_anchor != *external_anchor {
+        return Err(BnsRegistryError::InvalidMutation(format!(
+            "checkpoint event external anchor {external_anchor} does not match transaction calldata {call_anchor}"
+        )));
+    }
+    Ok(Some(LogCheckpoint {
+        log_root: log_root.clone(),
+        last_seq: *last_seq,
+        issued_at: *issued_at,
+        issuer: principal_from_evm(call.issuer.clone())?,
+        external_anchor: external_anchor.clone(),
+    }))
 }
 
 fn polling_delay(idle_interval: Duration, failed: bool, has_backlog: bool) -> Duration {

--- a/src/components/bns-indexer/src/sync.rs
+++ b/src/components/bns-indexer/src/sync.rs
@@ -366,6 +366,7 @@ where
         };
 
         if should_reset {
+            self.chain_client.invalidate_mined_receipts_from(0);
             self.store
                 .transact(|tx| tx.reset_indexer_projection(&self.source))?;
         }

--- a/src/components/bns-indexer/tests/sync_config.rs
+++ b/src/components/bns-indexer/tests/sync_config.rs
@@ -20,6 +20,10 @@ fn sync_source_id_includes_network_chain_and_contract() {
         testnet.source_id().unwrap(),
         production.source_id().unwrap()
     );
+    assert_eq!(
+        BnsIndexerSyncConfig::new(testnet.clone()).max_block_span,
+        500
+    );
 
     testnet.network.clear();
     assert!(BnsIndexerSyncConfig::new(testnet).validate().is_err());

--- a/src/components/bns-indexer/tests/sync_mock_rpc.rs
+++ b/src/components/bns-indexer/tests/sync_mock_rpc.rs
@@ -16,8 +16,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use alloy_sol_types::{SolCall, SolEvent};
-use bns_evm::{address, Address, Bns, B256};
+use alloy_sol_types::{sol, SolCall, SolEvent};
+use bns_evm::{address, Address, Bns, Bytes, B256, MULTICALL3_ADDRESS, U256};
 use bns_indexer::{
     sync_bns_contract_once, BnsBlockSyncSourceConfig, BnsContractEventIndexer,
     BnsIndexerSyncConfig, BnsRegistryError, BnsRegistryStore, DocumentStatus, NameStatus,
@@ -30,6 +30,20 @@ const CONTRACT: &str = "0x2222222222222222222222222222222222222222";
 const ACTOR: Address = address!("1000000000000000000000000000000000000001");
 const OWNER: Address = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
+sol! {
+    interface TestMulticall3 {
+        struct Call {
+            address target;
+            bytes callData;
+        }
+
+        function aggregate(Call[] calldata calls)
+            external
+            payable
+            returns (uint256 blockNumber, bytes[] memory returnData);
+    }
+}
+
 // ===== Mock JSON-RPC 服务 =====
 
 #[derive(Default, Clone)]
@@ -39,6 +53,8 @@ struct MockConfig {
     logs_json: Vec<serde_json::Value>,
     // selector(hex, no 0x) -> eth_call 返回 hex（含 0x）。
     eth_call_returns: HashMap<String, String>,
+    // Multicall3 aggregate 返回值（含 0x）；未设置时模拟目标链不支持并触发回退。
+    multicall_return: Option<String>,
     // tx hash(lowercase, 含 0x) -> input calldata hex（含 0x），供 decode_bns_call 补全入参。
     txs: HashMap<String, String>,
     // block number -> block hash（含 0x），用于游标 reorg 检测。
@@ -49,6 +65,7 @@ struct MockEthRpc {
     endpoint: String,
     config: Arc<Mutex<MockConfig>>,
     get_logs_calls: Arc<Mutex<u64>>,
+    eth_call_calls: Arc<Mutex<u64>>,
 }
 
 impl MockEthRpc {
@@ -57,8 +74,10 @@ impl MockEthRpc {
         let endpoint = format!("http://{}", listener.local_addr().unwrap());
         let config = Arc::new(Mutex::new(config));
         let get_logs_calls = Arc::new(Mutex::new(0u64));
+        let eth_call_calls = Arc::new(Mutex::new(0u64));
         let cfg = config.clone();
         let calls = get_logs_calls.clone();
+        let view_calls = eth_call_calls.clone();
         tokio::spawn(async move {
             loop {
                 let (mut stream, _) = match listener.accept().await {
@@ -67,6 +86,7 @@ impl MockEthRpc {
                 };
                 let cfg = cfg.clone();
                 let calls = calls.clone();
+                let view_calls = view_calls.clone();
                 tokio::spawn(async move {
                     let request = read_http_request(&mut stream).await;
                     let body = request
@@ -77,7 +97,7 @@ impl MockEthRpc {
                         serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
                     let id = req["id"].clone();
                     let method = req["method"].as_str().unwrap_or("");
-                    let result = handle_method(method, &req, &cfg, &calls);
+                    let result = handle_method(method, &req, &cfg, &calls, &view_calls);
                     let payload = serde_json::json!({"jsonrpc":"2.0","id":id,"result":result});
                     let body = serde_json::to_string(&payload).unwrap();
                     // 每个连接只服务一次请求即关闭；用 `Connection: close` 显式告知客户端
@@ -95,6 +115,7 @@ impl MockEthRpc {
             endpoint,
             config,
             get_logs_calls,
+            eth_call_calls,
         }
     }
 
@@ -105,6 +126,10 @@ impl MockEthRpc {
     fn get_logs_calls(&self) -> u64 {
         *self.get_logs_calls.lock().unwrap()
     }
+
+    fn eth_call_calls(&self) -> u64 {
+        *self.eth_call_calls.lock().unwrap()
+    }
 }
 
 fn handle_method(
@@ -112,6 +137,7 @@ fn handle_method(
     req: &serde_json::Value,
     cfg: &Arc<Mutex<MockConfig>>,
     calls: &Arc<Mutex<u64>>,
+    view_calls: &Arc<Mutex<u64>>,
 ) -> serde_json::Value {
     let cfg = cfg.lock().unwrap();
     match method {
@@ -142,6 +168,15 @@ fn handle_method(
             }
         }
         "eth_call" => {
+            *view_calls.lock().unwrap() += 1;
+            let to = req["params"][0]["to"].as_str().unwrap_or("");
+            if to.eq_ignore_ascii_case(&format!("{MULTICALL3_ADDRESS:#x}")) {
+                return cfg
+                    .multicall_return
+                    .clone()
+                    .map(serde_json::Value::String)
+                    .unwrap_or_else(|| serde_json::Value::String("0x".to_string()));
+            }
             let data = req["params"][0]["data"].as_str().unwrap_or("");
             let selector = data.trim_start_matches("0x").get(0..8).unwrap_or("");
             cfg.eth_call_returns
@@ -654,11 +689,28 @@ async fn sync_projects_document_published_via_mixed_eth_call_strategy() {
         ),
     ];
 
+    let multicall_return = format!(
+        "0x{}",
+        hex::encode(TestMulticall3::aggregateCall::abi_encode_returns(
+            &TestMulticall3::aggregateReturn {
+                blockNumber: U256::from(1),
+                returnData: vec![
+                    Bytes::from(Bns::queryNameStateCall::abi_encode_returns(
+                        &evm_name_state("alice", 2),
+                    )),
+                    Bytes::from(Bns::getDocumentVersionCall::abi_encode_returns(
+                        &evm_document_state("alice", "dns_txt", 3),
+                    )),
+                ],
+            },
+        ))
+    );
     let mock = MockEthRpc::start(MockConfig {
         chain_id: 31_337,
         block_number: 1,
         logs_json: logs,
         eth_call_returns,
+        multicall_return: Some(multicall_return),
         txs: HashMap::new(),
         ..Default::default()
     })
@@ -671,6 +723,7 @@ async fn sync_projects_document_published_via_mixed_eth_call_strategy() {
         .unwrap();
     assert_eq!(outcome.protocol_events_seen, 1);
     assert_eq!(outcome.registry_events_stored, 1);
+    assert_eq!(mock.eth_call_calls(), 1, "two reads use one Multicall");
 
     // 投影 = eth_call 拉回的最新快照（而非事件字段回放）。
     let (name_state, doc_state, events) = store

--- a/src/components/bns-indexer/tests/sync_mock_rpc.rs
+++ b/src/components/bns-indexer/tests/sync_mock_rpc.rs
@@ -852,6 +852,91 @@ async fn sync_projects_document_published_via_mixed_eth_call_strategy() {
 }
 
 #[tokio::test]
+async fn sync_deduplicates_projection_reads_across_registry_events() {
+    let tx_hash = B256::repeat_byte(0xDE);
+    let logs = vec![
+        protocol_event_log(6, 0x43, 1),
+        event_log_json_with_tx(
+            &Bns::NameRegistered {
+                nameHash: B256::repeat_byte(0x09),
+                name: "alice".to_string(),
+                assetOwner: OWNER,
+                actor: ACTOR,
+                expireAt: 1_000,
+                lineageEpoch: 0,
+                nameSeq: 1,
+            },
+            1,
+            tx_hash,
+        ),
+        protocol_event_log(7, 0x44, 1),
+        event_log_json_with_tx(
+            &Bns::DocumentPublished {
+                nameHash: B256::repeat_byte(0x09),
+                name: "alice".to_string(),
+                docType: "dns_txt".to_string(),
+                version: 3,
+                actor: ACTOR,
+                contentHash: B256::repeat_byte(0x22),
+                documentStateHash: B256::repeat_byte(0x33),
+            },
+            1,
+            tx_hash,
+        ),
+    ];
+    let multicall_return = format!(
+        "0x{}",
+        hex::encode(TestMulticall3::aggregateCall::abi_encode_returns(
+            &TestMulticall3::aggregateReturn {
+                blockNumber: U256::from(1),
+                returnData: vec![
+                    Bytes::from(Bns::queryNameStateCall::abi_encode_returns(
+                        &evm_name_state("alice", 2),
+                    )),
+                    Bytes::from(Bns::getDocumentVersionCall::abi_encode_returns(
+                        &evm_document_state("alice", "dns_txt", 3),
+                    )),
+                ],
+            },
+        ))
+    );
+    let mock = MockEthRpc::start(MockConfig {
+        chain_id: 31_337,
+        block_number: 1,
+        logs_json: logs,
+        multicall_return: Some(multicall_return),
+        ..Default::default()
+    })
+    .await;
+    let store = SqliteBnsRegistryStore::open_memory().unwrap();
+
+    let outcome = sync_bns_contract_once(
+        &store,
+        with_endpoint(config_for_chain(31_337), &mock.endpoint),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.registry_events_stored, 2);
+    assert_eq!(
+        mock.eth_call_calls(),
+        1,
+        "the repeated name read and document read share one Multicall"
+    );
+    assert_eq!(mock.transaction_lookup_calls(), 0);
+    let (name, document) = store
+        .transact(|tx| {
+            Ok((
+                tx.get_name("alice")?,
+                tx.get_current_document("alice", "dns_txt")?,
+            ))
+        })
+        .unwrap();
+    assert_eq!(name.unwrap().name_seq, 2);
+    assert_eq!(document.unwrap().version, 3);
+}
+
+#[tokio::test]
 async fn sync_backfills_controller_rules_from_decoded_call() {
     // ControllerPolicyUpdated 事件不携带 rules：indexer 用 decode_bns_call（按 tx hash）补全入参。
     let tx_hash = B256::repeat_byte(0xCA);

--- a/src/components/bns-indexer/tests/sync_mock_rpc.rs
+++ b/src/components/bns-indexer/tests/sync_mock_rpc.rs
@@ -669,6 +669,33 @@ async fn polling_loop_runs_sync_once_repeatedly() {
 }
 
 #[tokio::test]
+async fn polling_loop_processes_backlog_without_idle_sleep() {
+    let mock = MockEthRpc::start(MockConfig {
+        chain_id: 31_337,
+        block_number: 2,
+        logs_json: Vec::new(),
+        ..Default::default()
+    })
+    .await;
+    let store = SqliteBnsRegistryStore::open_memory().unwrap();
+    let mut config = with_endpoint(config_for_chain(31_337), &mock.endpoint);
+    config.max_block_span = 1;
+    let indexer = BnsContractEventIndexer::new(&store, config).unwrap();
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let outcomes = observed.clone();
+
+    tokio::select! {
+        _ = indexer.run_polling_loop(Duration::from_secs(3_600), move |outcome| {
+            outcomes.lock().unwrap().push(outcome.unwrap().to_block);
+        }) => panic!("polling loop should not return"),
+        _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+    }
+
+    assert_eq!(*observed.lock().unwrap(), [Some(0), Some(1), Some(2)]);
+    assert_eq!(mock.get_logs_calls(), 3);
+}
+
+#[tokio::test]
 async fn sync_projects_document_published_via_mixed_eth_call_strategy() {
     // 混合投影：DocumentPublished 事件只定位 name/doc，随后 eth_call 拉权威态写投影。
     let mut eth_call_returns = HashMap::new();

--- a/src/components/bns-indexer/tests/sync_mock_rpc.rs
+++ b/src/components/bns-indexer/tests/sync_mock_rpc.rs
@@ -1474,6 +1474,79 @@ async fn sync_projects_log_checkpoint_and_overwrites_on_last_seq_conflict() {
     assert_eq!(second.log_root, format!("{:#x}", B256::repeat_byte(0xC2)));
 }
 
+#[tokio::test]
+async fn sync_projects_checkpoint_from_event_and_calldata_without_eth_call() {
+    let tx_hash = B256::repeat_byte(0xCF);
+    let external_anchor = B256::repeat_byte(0xA5);
+    let issuer = bns_evm::Principal {
+        kind: bns_evm::PrincipalKind::ChainAccount,
+        value: bns_evm::Bytes::copy_from_slice(OWNER.as_slice()),
+    };
+    let calldata = Bns::publishLogCheckpointCall {
+        issuer: issuer.clone(),
+        externalAnchor: external_anchor,
+    }
+    .abi_encode();
+    let mut txs = HashMap::new();
+    txs.insert(
+        format!("{tx_hash:#x}").to_lowercase(),
+        format!("0x{}", hex::encode(calldata)),
+    );
+    let logs = vec![
+        protocol_event_log(12, 0xC3, 1),
+        event_log_json_with_tx(
+            &Bns::LogCheckpointPublished {
+                logRoot: B256::repeat_byte(0xC3),
+                actor: ACTOR,
+                lastSeq: 11,
+                issuedAt: 300,
+                externalAnchor: external_anchor,
+            },
+            1,
+            tx_hash,
+        ),
+    ];
+    let mock = MockEthRpc::start(MockConfig {
+        chain_id: 31_337,
+        block_number: 1,
+        logs_json: logs,
+        txs,
+        ..Default::default()
+    })
+    .await;
+    let store = SqliteBnsRegistryStore::open_memory().unwrap();
+
+    sync_bns_contract_once(
+        &store,
+        with_endpoint(config_for_chain(31_337), &mock.endpoint),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(mock.transaction_lookup_calls(), 1);
+    assert_eq!(
+        mock.eth_call_calls(),
+        0,
+        "complete event and calldata projection skips latestCheckpoint"
+    );
+    let checkpoint = store
+        .transact(|tx| tx.latest_checkpoint())
+        .unwrap()
+        .expect("checkpoint projected");
+    assert_eq!(
+        checkpoint.log_root,
+        format!("{:#x}", B256::repeat_byte(0xC3))
+    );
+    assert_eq!(checkpoint.last_seq, 11);
+    assert_eq!(checkpoint.issued_at, 300);
+    assert_eq!(
+        checkpoint.issuer.kind,
+        bns_indexer::PrincipalKind::ChainAccount
+    );
+    assert_eq!(checkpoint.issuer.value, format!("{OWNER:#x}"));
+    assert_eq!(checkpoint.external_anchor, format!("{external_anchor:#x}"));
+}
+
 fn sample_name_state() -> bns_indexer::NameState {
     bns_indexer::NameState {
         name: "alice".to_string(),

--- a/src/components/bns-indexer/tests/sync_mock_rpc.rs
+++ b/src/components/bns-indexer/tests/sync_mock_rpc.rs
@@ -66,6 +66,7 @@ struct MockEthRpc {
     config: Arc<Mutex<MockConfig>>,
     get_logs_calls: Arc<Mutex<u64>>,
     eth_call_calls: Arc<Mutex<u64>>,
+    chain_id_calls: Arc<AtomicUsize>,
 }
 
 impl MockEthRpc {
@@ -75,9 +76,11 @@ impl MockEthRpc {
         let config = Arc::new(Mutex::new(config));
         let get_logs_calls = Arc::new(Mutex::new(0u64));
         let eth_call_calls = Arc::new(Mutex::new(0u64));
+        let chain_id_calls = Arc::new(AtomicUsize::new(0));
         let cfg = config.clone();
         let calls = get_logs_calls.clone();
         let view_calls = eth_call_calls.clone();
+        let network_calls = chain_id_calls.clone();
         tokio::spawn(async move {
             loop {
                 let (mut stream, _) = match listener.accept().await {
@@ -87,6 +90,7 @@ impl MockEthRpc {
                 let cfg = cfg.clone();
                 let calls = calls.clone();
                 let view_calls = view_calls.clone();
+                let network_calls = network_calls.clone();
                 tokio::spawn(async move {
                     let request = read_http_request(&mut stream).await;
                     let body = request
@@ -97,7 +101,8 @@ impl MockEthRpc {
                         serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
                     let id = req["id"].clone();
                     let method = req["method"].as_str().unwrap_or("");
-                    let result = handle_method(method, &req, &cfg, &calls, &view_calls);
+                    let result =
+                        handle_method(method, &req, &cfg, &calls, &view_calls, &network_calls);
                     let payload = serde_json::json!({"jsonrpc":"2.0","id":id,"result":result});
                     let body = serde_json::to_string(&payload).unwrap();
                     // 每个连接只服务一次请求即关闭；用 `Connection: close` 显式告知客户端
@@ -116,6 +121,7 @@ impl MockEthRpc {
             config,
             get_logs_calls,
             eth_call_calls,
+            chain_id_calls,
         }
     }
 
@@ -130,6 +136,10 @@ impl MockEthRpc {
     fn eth_call_calls(&self) -> u64 {
         *self.eth_call_calls.lock().unwrap()
     }
+
+    fn chain_id_calls(&self) -> usize {
+        self.chain_id_calls.load(Ordering::SeqCst)
+    }
 }
 
 fn handle_method(
@@ -138,10 +148,14 @@ fn handle_method(
     cfg: &Arc<Mutex<MockConfig>>,
     calls: &Arc<Mutex<u64>>,
     view_calls: &Arc<Mutex<u64>>,
+    network_calls: &Arc<AtomicUsize>,
 ) -> serde_json::Value {
     let cfg = cfg.lock().unwrap();
     match method {
-        "eth_chainId" => serde_json::Value::String(format!("0x{:x}", cfg.chain_id)),
+        "eth_chainId" => {
+            network_calls.fetch_add(1, Ordering::SeqCst);
+            serde_json::Value::String(format!("0x{:x}", cfg.chain_id))
+        }
         "eth_blockNumber" => serde_json::Value::String(format!("0x{:x}", cfg.block_number)),
         "eth_getLogs" => {
             *calls.lock().unwrap() += 1;
@@ -646,6 +660,11 @@ async fn polling_loop_runs_sync_once_repeatedly() {
     assert!(
         outcomes.load(Ordering::SeqCst) >= 2,
         "polling loop should call sync_once more than once"
+    );
+    assert_eq!(
+        mock.chain_id_calls(),
+        1,
+        "one indexer instance caches the validated chain id"
     );
 }
 

--- a/src/components/bns-indexer/tests/sync_mock_rpc.rs
+++ b/src/components/bns-indexer/tests/sync_mock_rpc.rs
@@ -68,6 +68,7 @@ struct MockEthRpc {
     eth_call_calls: Arc<Mutex<u64>>,
     chain_id_calls: Arc<AtomicUsize>,
     latest_block_calls: Arc<AtomicUsize>,
+    transaction_lookup_calls: Arc<AtomicUsize>,
 }
 
 impl MockEthRpc {
@@ -79,11 +80,13 @@ impl MockEthRpc {
         let eth_call_calls = Arc::new(Mutex::new(0u64));
         let chain_id_calls = Arc::new(AtomicUsize::new(0));
         let latest_block_calls = Arc::new(AtomicUsize::new(0));
+        let transaction_lookup_calls = Arc::new(AtomicUsize::new(0));
         let cfg = config.clone();
         let calls = get_logs_calls.clone();
         let view_calls = eth_call_calls.clone();
         let network_calls = chain_id_calls.clone();
         let head_calls = latest_block_calls.clone();
+        let transaction_calls = transaction_lookup_calls.clone();
         tokio::spawn(async move {
             loop {
                 let (mut stream, _) = match listener.accept().await {
@@ -95,6 +98,7 @@ impl MockEthRpc {
                 let view_calls = view_calls.clone();
                 let network_calls = network_calls.clone();
                 let head_calls = head_calls.clone();
+                let transaction_calls = transaction_calls.clone();
                 tokio::spawn(async move {
                     let request = read_http_request(&mut stream).await;
                     let body = request
@@ -113,6 +117,7 @@ impl MockEthRpc {
                         &view_calls,
                         &network_calls,
                         &head_calls,
+                        &transaction_calls,
                     );
                     let payload = serde_json::json!({"jsonrpc":"2.0","id":id,"result":result});
                     let body = serde_json::to_string(&payload).unwrap();
@@ -134,6 +139,7 @@ impl MockEthRpc {
             eth_call_calls,
             chain_id_calls,
             latest_block_calls,
+            transaction_lookup_calls,
         }
     }
 
@@ -156,6 +162,10 @@ impl MockEthRpc {
     fn latest_block_calls(&self) -> usize {
         self.latest_block_calls.load(Ordering::SeqCst)
     }
+
+    fn transaction_lookup_calls(&self) -> usize {
+        self.transaction_lookup_calls.load(Ordering::SeqCst)
+    }
 }
 
 fn handle_method(
@@ -166,6 +176,7 @@ fn handle_method(
     view_calls: &Arc<Mutex<u64>>,
     network_calls: &Arc<AtomicUsize>,
     head_calls: &Arc<AtomicUsize>,
+    transaction_calls: &Arc<AtomicUsize>,
 ) -> serde_json::Value {
     let cfg = cfg.lock().unwrap();
     match method {
@@ -197,6 +208,7 @@ fn handle_method(
             })
         }
         "eth_getTransactionByHash" => {
+            transaction_calls.fetch_add(1, Ordering::SeqCst);
             let hash = req["params"][0].as_str().unwrap_or("").to_lowercase();
             match cfg.txs.get(&hash) {
                 Some(input) => serde_json::json!({ "hash": hash, "input": input }),
@@ -746,9 +758,11 @@ async fn sync_projects_document_published_via_mixed_eth_call_strategy() {
     );
 
     // 日志：ProtocolEvent（携带 seq/logRoot）+ DocumentPublished（具体事件）。
+    // 普通文档事件即使带 tx hash，也不需要读取交易 calldata。
+    let tx_hash = B256::repeat_byte(0xDD);
     let logs = vec![
         protocol_event_log(7, 0x44, 1),
-        event_log_json(
+        event_log_json_with_tx(
             &Bns::DocumentPublished {
                 nameHash: B256::repeat_byte(0x09),
                 name: "alice".to_string(),
@@ -759,6 +773,7 @@ async fn sync_projects_document_published_via_mixed_eth_call_strategy() {
                 documentStateHash: B256::repeat_byte(0x33),
             },
             1,
+            tx_hash,
         ),
     ];
 
@@ -797,6 +812,11 @@ async fn sync_projects_document_published_via_mixed_eth_call_strategy() {
     assert_eq!(outcome.protocol_events_seen, 1);
     assert_eq!(outcome.registry_events_stored, 1);
     assert_eq!(mock.eth_call_calls(), 1, "two reads use one Multicall");
+    assert_eq!(
+        mock.transaction_lookup_calls(),
+        0,
+        "document projection does not need transaction calldata"
+    );
 
     // 投影 = eth_call 拉回的最新快照（而非事件字段回放）。
     let (name_state, doc_state, events) = store
@@ -913,6 +933,7 @@ async fn sync_backfills_controller_rules_from_decoded_call() {
     .await
     .unwrap();
     assert_eq!(outcome.registry_events_stored, 1);
+    assert_eq!(mock.transaction_lookup_calls(), 1);
 
     let rules = store
         .transact(|tx| tx.get_controller_policy("alice"))

--- a/src/components/bns-indexer/tests/sync_mock_rpc.rs
+++ b/src/components/bns-indexer/tests/sync_mock_rpc.rs
@@ -67,6 +67,7 @@ struct MockEthRpc {
     get_logs_calls: Arc<Mutex<u64>>,
     eth_call_calls: Arc<Mutex<u64>>,
     chain_id_calls: Arc<AtomicUsize>,
+    latest_block_calls: Arc<AtomicUsize>,
 }
 
 impl MockEthRpc {
@@ -77,10 +78,12 @@ impl MockEthRpc {
         let get_logs_calls = Arc::new(Mutex::new(0u64));
         let eth_call_calls = Arc::new(Mutex::new(0u64));
         let chain_id_calls = Arc::new(AtomicUsize::new(0));
+        let latest_block_calls = Arc::new(AtomicUsize::new(0));
         let cfg = config.clone();
         let calls = get_logs_calls.clone();
         let view_calls = eth_call_calls.clone();
         let network_calls = chain_id_calls.clone();
+        let head_calls = latest_block_calls.clone();
         tokio::spawn(async move {
             loop {
                 let (mut stream, _) = match listener.accept().await {
@@ -91,6 +94,7 @@ impl MockEthRpc {
                 let calls = calls.clone();
                 let view_calls = view_calls.clone();
                 let network_calls = network_calls.clone();
+                let head_calls = head_calls.clone();
                 tokio::spawn(async move {
                     let request = read_http_request(&mut stream).await;
                     let body = request
@@ -101,8 +105,15 @@ impl MockEthRpc {
                         serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
                     let id = req["id"].clone();
                     let method = req["method"].as_str().unwrap_or("");
-                    let result =
-                        handle_method(method, &req, &cfg, &calls, &view_calls, &network_calls);
+                    let result = handle_method(
+                        method,
+                        &req,
+                        &cfg,
+                        &calls,
+                        &view_calls,
+                        &network_calls,
+                        &head_calls,
+                    );
                     let payload = serde_json::json!({"jsonrpc":"2.0","id":id,"result":result});
                     let body = serde_json::to_string(&payload).unwrap();
                     // 每个连接只服务一次请求即关闭；用 `Connection: close` 显式告知客户端
@@ -122,6 +133,7 @@ impl MockEthRpc {
             get_logs_calls,
             eth_call_calls,
             chain_id_calls,
+            latest_block_calls,
         }
     }
 
@@ -140,6 +152,10 @@ impl MockEthRpc {
     fn chain_id_calls(&self) -> usize {
         self.chain_id_calls.load(Ordering::SeqCst)
     }
+
+    fn latest_block_calls(&self) -> usize {
+        self.latest_block_calls.load(Ordering::SeqCst)
+    }
 }
 
 fn handle_method(
@@ -149,6 +165,7 @@ fn handle_method(
     calls: &Arc<Mutex<u64>>,
     view_calls: &Arc<Mutex<u64>>,
     network_calls: &Arc<AtomicUsize>,
+    head_calls: &Arc<AtomicUsize>,
 ) -> serde_json::Value {
     let cfg = cfg.lock().unwrap();
     match method {
@@ -162,8 +179,13 @@ fn handle_method(
             serde_json::Value::Array(cfg.logs_json.clone())
         }
         "eth_getBlockByNumber" => {
-            let block_number =
-                parse_rpc_quantity(req["params"][0].as_str().unwrap_or("0x0")).unwrap();
+            let block_tag = req["params"][0].as_str().unwrap_or("0x0");
+            let block_number = if block_tag == "latest" {
+                head_calls.fetch_add(1, Ordering::SeqCst);
+                cfg.block_number
+            } else {
+                parse_rpc_quantity(block_tag).unwrap()
+            };
             serde_json::json!({
                 "number": format!("0x{block_number:x}"),
                 "hash": cfg
@@ -693,6 +715,11 @@ async fn polling_loop_processes_backlog_without_idle_sleep() {
 
     assert_eq!(*observed.lock().unwrap(), [Some(0), Some(1), Some(2)]);
     assert_eq!(mock.get_logs_calls(), 3);
+    assert_eq!(
+        mock.latest_block_calls(),
+        1,
+        "one latest header is reused while draining backlog"
+    );
 }
 
 #[tokio::test]

--- a/src/components/bns-server/src/bin/bns_dv.rs
+++ b/src/components/bns-server/src/bin/bns_dv.rs
@@ -12,6 +12,9 @@
 //!
 //! 这是开发/调试用工具（被 scripts/dv-up.sh / dv-smoke.sh 调用），不是生产服务。
 
+#[path = "bns_dv/cluster.rs"]
+mod bns_dv_cluster;
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -22,6 +25,7 @@ use bns_client::{
     BnsEvmTxSubmission, BnsIndexerApi, BnsIndexerClient, BnsPublishDocumentReq, BnsRegisterNameReq,
     StaticBnsEvmKeyManager,
 };
+use bns_dv_cluster::{create_database_parent, merge_cluster_serve_flags};
 use bns_evm::BnsChainClient;
 use bns_indexer::{
     default_document_update, BnsBlockSyncSourceConfig, BnsContractEventIndexer,
@@ -165,13 +169,17 @@ async fn main() {
 async fn run() -> Result<(), DynError> {
     let mut args = std::env::args().skip(1);
     let command = args.next().unwrap_or_default();
-    let flags = parse_flags(args.collect());
+    let mut flags = parse_flags(args.collect());
+    if command == "serve" && flags.contains_key("cluster") {
+        flags = merge_cluster_serve_flags(flags)?;
+    }
     match command.as_str() {
         "serve" => serve(flags).await,
         "smoke" => smoke(flags).await,
         other => Err(format!(
             "unknown subcommand `{other}`; expected `serve` or `smoke`\n\
              usage:\n  \
+             bns-dv serve --cluster [--rpc <url>] [--contract <addr>] [--chain-id <n>] [--db <path>] [--listen <addr>] [--start-block n] [--confirmations n] [--interval-ms n] [--max-block-span n]\n  \
              bns-dv serve --rpc <url> --contract <addr> --chain-id <n> --db <path> --listen <addr> [--start-block n] [--confirmations n] [--interval-ms n] [--max-block-span n] [--config seed.yaml] [--seed-key 0x..]\n  \
              bns-dv smoke --server <url> --rpc <url> --contract <addr> --chain-id <n> --key <0x..> [--name alice] [--timeout-ms n]"
         )
@@ -191,6 +199,10 @@ async fn serve(flags: HashMap<String, String>) -> Result<(), DynError> {
     let confirmations: u64 = flags.get("confirmations").map_or(Ok(0), |v| v.parse())?;
     let interval_ms: u64 = flags.get("interval-ms").map_or(Ok(15_000), |v| v.parse())?;
     let max_block_span: u64 = flags.get("max-block-span").map_or(Ok(500), |v| v.parse())?;
+
+    if flags.contains_key("cluster") {
+        create_database_parent(&db)?;
+    }
 
     let mut source = BnsBlockSyncSourceConfig::anvil(rpc.clone(), contract.clone(), start_block);
     source.chain_id = chain_id;
@@ -961,7 +973,7 @@ async fn smoke(flags: HashMap<String, String>) -> Result<(), DynError> {
     Ok(())
 }
 
-// ===== 简易 --flag value 解析 =====
+// ===== cluster 配置和简易 --flag value 解析 =====
 
 fn parse_flags(args: Vec<String>) -> HashMap<String, String> {
     let mut flags = HashMap::new();
@@ -970,6 +982,8 @@ fn parse_flags(args: Vec<String>) -> HashMap<String, String> {
         if let Some(name) = arg.strip_prefix("--") {
             if let Some((k, v)) = name.split_once('=') {
                 flags.insert(k.to_string(), v.to_string());
+            } else if name == "cluster" {
+                flags.insert(name.to_string(), "true".to_string());
             } else {
                 let value = iter.next().unwrap_or_default();
                 flags.insert(name.to_string(), value);
@@ -1005,6 +1019,20 @@ mod tests {
 
     const CHAIN_ID: u64 = 31_337;
     const DEPLOYER_KEY: &str = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+
+    #[test]
+    fn cluster_flag_does_not_consume_the_next_option() {
+        let parsed = parse_flags(vec![
+            "--cluster".to_string(),
+            "--rpc".to_string(),
+            "http://override:8545".to_string(),
+        ]);
+        assert_eq!(parsed.get("cluster").map(String::as_str), Some("true"));
+        assert_eq!(
+            parsed.get("rpc").map(String::as_str),
+            Some("http://override:8545")
+        );
+    }
 
     fn e2e_tools_available() -> bool {
         fn has(bin: &str) -> bool {

--- a/src/components/bns-server/src/bin/bns_dv.rs
+++ b/src/components/bns-server/src/bin/bns_dv.rs
@@ -22,6 +22,7 @@ use bns_client::{
     BnsEvmTxSubmission, BnsIndexerApi, BnsIndexerClient, BnsPublishDocumentReq, BnsRegisterNameReq,
     StaticBnsEvmKeyManager,
 };
+use bns_evm::BnsChainClient;
 use bns_indexer::{
     default_document_update, BnsBlockSyncSourceConfig, BnsContractEventIndexer,
     BnsIndexerSyncConfig, CallAuthority, DocumentRef, DocumentStatus, MutationGuard, NameState,
@@ -200,10 +201,16 @@ async fn serve(flags: HashMap<String, String>) -> Result<(), DynError> {
     // server 与 indexer 各开一条到同一 SQLite 文件的连接（WAL 并发）。
     let server_store = SqliteBnsRegistryStore::open(&db)?;
     let indexer_store = SqliteBnsRegistryStore::open(&db)?;
+    let chain_client = Arc::new(BnsChainClient::new(rpc.clone()));
 
     // indexer 轮询循环。
+    let indexer_chain_client = chain_client.clone();
     tokio::spawn(async move {
-        let indexer = match BnsContractEventIndexer::new(&indexer_store, sync_config.clone()) {
+        let indexer = match BnsContractEventIndexer::new_with_chain_client(
+            &indexer_store,
+            sync_config.clone(),
+            indexer_chain_client,
+        ) {
             Ok(indexer) => indexer,
             Err(err) => {
                 eprintln!("[indexer] config error: {err}");
@@ -234,9 +241,9 @@ async fn serve(flags: HashMap<String, String>) -> Result<(), DynError> {
     run_on_init_txs(&flags, &rpc, &contract, chain_id, &db).await?;
 
     let server: Arc<dyn HttpServer> = Arc::new(
-        BnsContractHttpServer::from_contract_store_with_chain_config(
+        BnsContractHttpServer::from_contract_store_with_chain_client(
             server_store,
-            rpc.clone(),
+            chain_client,
             contract.clone(),
             chain_id,
         ),

--- a/src/components/bns-server/src/bin/bns_dv.rs
+++ b/src/components/bns-server/src/bin/bns_dv.rs
@@ -172,7 +172,7 @@ async fn run() -> Result<(), DynError> {
         other => Err(format!(
             "unknown subcommand `{other}`; expected `serve` or `smoke`\n\
              usage:\n  \
-             bns-dv serve --rpc <url> --contract <addr> --chain-id <n> --db <path> --listen <addr> [--start-block n] [--confirmations n] [--interval-ms n] [--config seed.yaml] [--seed-key 0x..]\n  \
+             bns-dv serve --rpc <url> --contract <addr> --chain-id <n> --db <path> --listen <addr> [--start-block n] [--confirmations n] [--interval-ms n] [--max-block-span n] [--config seed.yaml] [--seed-key 0x..]\n  \
              bns-dv smoke --server <url> --rpc <url> --contract <addr> --chain-id <n> --key <0x..> [--name alice] [--timeout-ms n]"
         )
         .into()),
@@ -189,12 +189,14 @@ async fn serve(flags: HashMap<String, String>) -> Result<(), DynError> {
     let listen = require(&flags, "listen")?;
     let start_block: u64 = flags.get("start-block").map_or(Ok(0), |v| v.parse())?;
     let confirmations: u64 = flags.get("confirmations").map_or(Ok(0), |v| v.parse())?;
-    let interval_ms: u64 = flags.get("interval-ms").map_or(Ok(1000), |v| v.parse())?;
+    let interval_ms: u64 = flags.get("interval-ms").map_or(Ok(15_000), |v| v.parse())?;
+    let max_block_span: u64 = flags.get("max-block-span").map_or(Ok(500), |v| v.parse())?;
 
     let mut source = BnsBlockSyncSourceConfig::anvil(rpc.clone(), contract.clone(), start_block);
     source.chain_id = chain_id;
     let mut sync_config = BnsIndexerSyncConfig::new(source.clone());
     sync_config.confirmations = confirmations;
+    sync_config.max_block_span = max_block_span;
     sync_config.validate()?;
     let source_id = source.source_id()?;
 
@@ -264,7 +266,8 @@ async fn serve(flags: HashMap<String, String>) -> Result<(), DynError> {
 
     eprintln!(
         "[serve] bns-dv ready\n  rpc={rpc}\n  contract={contract}\n  chain_id={chain_id}\n  \
-         source={source_id}\n  db={db}\n  listen=http://{listen}  (rpc_path={})",
+         source={source_id}\n  db={db}\n  interval_ms={interval_ms}\n  \
+         max_block_span={max_block_span}\n  listen=http://{listen}  (rpc_path={})",
         server_rpc_path()
     );
 

--- a/src/components/bns-server/src/bin/bns_dv.rs
+++ b/src/components/bns-server/src/bin/bns_dv.rs
@@ -206,7 +206,15 @@ async fn serve(flags: HashMap<String, String>) -> Result<(), DynError> {
         source.contract_address()?,
         chain_id,
     ));
-    chain_client.validate_chain().await?;
+    loop {
+        match chain_client.validate_chain().await {
+            Ok(()) => break,
+            Err(err) => {
+                eprintln!("[chain] startup validation failed: {err}; retrying in 30 seconds");
+                tokio::time::sleep(Duration::from_secs(30)).await;
+            }
+        }
+    }
 
     // indexer 轮询循环。
     let indexer_chain_client = chain_client.clone();

--- a/src/components/bns-server/src/bin/bns_dv.rs
+++ b/src/components/bns-server/src/bin/bns_dv.rs
@@ -201,7 +201,12 @@ async fn serve(flags: HashMap<String, String>) -> Result<(), DynError> {
     // server 与 indexer 各开一条到同一 SQLite 文件的连接（WAL 并发）。
     let server_store = SqliteBnsRegistryStore::open(&db)?;
     let indexer_store = SqliteBnsRegistryStore::open(&db)?;
-    let chain_client = Arc::new(BnsChainClient::new(rpc.clone()));
+    let chain_client = Arc::new(BnsChainClient::new_with_chain_config(
+        rpc.clone(),
+        source.contract_address()?,
+        chain_id,
+    ));
+    chain_client.validate_chain().await?;
 
     // indexer 轮询循环。
     let indexer_chain_client = chain_client.clone();

--- a/src/components/bns-server/src/bin/bns_dv/cluster.rs
+++ b/src/components/bns-server/src/bin/bns_dv/cluster.rs
@@ -1,0 +1,335 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+type DynError = Box<dyn std::error::Error + Send + Sync>;
+
+const CLUSTER_CONFIG_PATH: &str = "/etc/cluster_config/cluster_config.json";
+const SECURITY_CONFIG_PATH: &str = "/etc/security/security_config.json";
+const APP_ID: &str = "bns_dv";
+const DATABASE_ROOT: &str = "/var/lib/bns-backend";
+const JSON_SAFE_INTEGER_MAX: u64 = 9_007_199_254_740_991;
+const SETTINGS_KEYS: [&str; 8] = [
+    "contract",
+    "chain_id",
+    "db",
+    "listen",
+    "start_block",
+    "confirmations",
+    "interval_ms",
+    "max_block_span",
+];
+const REQUIRED_SETTINGS_KEYS: [&str; 7] = [
+    "contract",
+    "chain_id",
+    "db",
+    "listen",
+    "start_block",
+    "confirmations",
+    "interval_ms",
+];
+
+pub fn merge_cluster_serve_flags(
+    command_line_flags: HashMap<String, String>,
+) -> Result<HashMap<String, String>, DynError> {
+    let cluster_config = read_json_config(CLUSTER_CONFIG_PATH, "Cluster Config")?;
+    let security_config = read_json_config(SECURITY_CONFIG_PATH, "Security Config")?;
+    let mut flags = cluster_serve_flags(&cluster_config, &security_config)?;
+    flags.extend(command_line_flags);
+    Ok(flags)
+}
+
+pub fn create_database_parent(db: &str) -> Result<(), DynError> {
+    let path = Path::new(db);
+    let Some(parent) = path.parent() else {
+        return Err(format!("cannot determine parent directory for {db}").into());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| {
+        format!(
+            "failed to create database directory {}: {err}",
+            parent.display()
+        )
+        .into()
+    })
+}
+
+fn read_json_config(path: &str, label: &str) -> Result<Value, DynError> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|err| format!("cannot read {label} at {path}: {err}"))?;
+    serde_json::from_str(&source)
+        .map_err(|err| format!("cannot parse {label} at {path}: {err}").into())
+}
+
+fn cluster_serve_flags(
+    cluster_config: &Value,
+    security_config: &Value,
+) -> Result<HashMap<String, String>, DynError> {
+    let cluster = json_object(cluster_config, "cluster config")?;
+    let apps = json_member_object(cluster, "apps", "apps")?;
+    let app_path = format!("apps.{APP_ID}");
+    let app = json_member_object(apps, APP_ID, &app_path)?;
+    let settings_path = format!("{app_path}.settings");
+    let settings = json_member_object(app, "settings", &settings_path)?;
+
+    let mut unknown_keys = settings
+        .keys()
+        .filter(|key| !SETTINGS_KEYS.contains(&key.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    unknown_keys.sort();
+    if !unknown_keys.is_empty() {
+        return invalid(format!(
+            "{settings_path} contains unknown keys: {}",
+            unknown_keys.join(", ")
+        ));
+    }
+    for key in REQUIRED_SETTINGS_KEYS {
+        if !settings.contains_key(key) {
+            return invalid(format!("{settings_path}.{key} is missing"));
+        }
+    }
+
+    let security = json_object(security_config, "security config")?;
+    let rpc = rpc_url(json_member(
+        security,
+        "chain_rpc_url",
+        "security.chain_rpc_url",
+    )?)?;
+    let contract = contract_address(setting(settings, &settings_path, "contract")?)?;
+    let chain_id = setting_integer(settings, &settings_path, "chain_id", 1)?;
+    let db = database_path(setting(settings, &settings_path, "db")?)?;
+    let listen = listen_address(setting(settings, &settings_path, "listen")?)?;
+    let start_block = setting_integer(settings, &settings_path, "start_block", 0)?;
+    let confirmations = setting_integer(settings, &settings_path, "confirmations", 0)?;
+    let interval_ms = setting_integer(settings, &settings_path, "interval_ms", 1)?;
+    let max_block_span = match settings.get("max_block_span") {
+        None | Some(Value::Null) => 500,
+        Some(value) => integer(value, &format!("{settings_path}.max_block_span"), 1)?,
+    };
+
+    Ok(HashMap::from([
+        ("rpc".to_string(), rpc),
+        ("contract".to_string(), contract),
+        ("chain-id".to_string(), chain_id.to_string()),
+        ("db".to_string(), db),
+        ("listen".to_string(), listen),
+        ("start-block".to_string(), start_block.to_string()),
+        ("confirmations".to_string(), confirmations.to_string()),
+        ("interval-ms".to_string(), interval_ms.to_string()),
+        ("max-block-span".to_string(), max_block_span.to_string()),
+    ]))
+}
+
+fn json_object<'a>(value: &'a Value, path: &str) -> Result<&'a Map<String, Value>, DynError> {
+    value
+        .as_object()
+        .ok_or_else(|| format!("invalid bns_dv configuration: {path} must be an object").into())
+}
+
+fn json_member<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> Result<&'a Value, DynError> {
+    object
+        .get(key)
+        .ok_or_else(|| format!("invalid bns_dv configuration: {path} is missing").into())
+}
+
+fn json_member_object<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> Result<&'a Map<String, Value>, DynError> {
+    json_object(json_member(object, key, path)?, path)
+}
+
+fn setting<'a>(
+    settings: &'a Map<String, Value>,
+    settings_path: &str,
+    key: &str,
+) -> Result<&'a Value, DynError> {
+    json_member(settings, key, &format!("{settings_path}.{key}"))
+}
+
+fn setting_integer(
+    settings: &Map<String, Value>,
+    settings_path: &str,
+    key: &str,
+    minimum: u64,
+) -> Result<u64, DynError> {
+    integer(
+        setting(settings, settings_path, key)?,
+        &format!("{settings_path}.{key}"),
+        minimum,
+    )
+}
+
+fn invalid<T>(message: impl Into<String>) -> Result<T, DynError> {
+    Err(format!("invalid bns_dv configuration: {}", message.into()).into())
+}
+
+fn non_empty_string(value: &Value, path: &str) -> Result<String, DynError> {
+    let Some(value) = value.as_str() else {
+        return invalid(format!("{path} must be a non-empty single-line string"));
+    };
+    if value.is_empty()
+        || value.trim() != value
+        || value
+            .chars()
+            .any(|character| matches!(character, '\0' | '\n' | '\r'))
+    {
+        return invalid(format!("{path} must be a non-empty single-line string"));
+    }
+    Ok(value.to_string())
+}
+
+fn integer(value: &Value, path: &str, minimum: u64) -> Result<u64, DynError> {
+    let Some(value) = value.as_u64() else {
+        return invalid(format!(
+            "{path} must be a safe integer greater than or equal to {minimum}"
+        ));
+    };
+    if value < minimum || value > JSON_SAFE_INTEGER_MAX {
+        return invalid(format!(
+            "{path} must be a safe integer greater than or equal to {minimum}"
+        ));
+    }
+    Ok(value)
+}
+
+fn contract_address(value: &Value) -> Result<String, DynError> {
+    let path = format!("apps.{APP_ID}.settings.contract");
+    let address = non_empty_string(value, &path)?;
+    let valid = address
+        .strip_prefix("0x")
+        .is_some_and(|hex| hex.len() == 40 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    if !valid {
+        return invalid(format!("{path} must be a 20-byte hex address"));
+    }
+    Ok(address)
+}
+
+fn database_path(value: &Value) -> Result<String, DynError> {
+    let path_name = format!("apps.{APP_ID}.settings.db");
+    let path = non_empty_string(value, &path_name)?;
+    let Some(relative) = path.strip_prefix(&format!("{DATABASE_ROOT}/")) else {
+        return invalid(format!("{path_name} must be below {DATABASE_ROOT}"));
+    };
+    if relative
+        .split('/')
+        .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        return invalid(format!("{path_name} must be a normalized file path"));
+    }
+    Ok(path)
+}
+
+fn listen_address(value: &Value) -> Result<String, DynError> {
+    let path = format!("apps.{APP_ID}.settings.listen");
+    let listen = non_empty_string(value, &path)?;
+    let valid = listen
+        .strip_prefix("127.0.0.1:")
+        .and_then(|port| port.parse::<u16>().ok())
+        .is_some_and(|port| port != 0);
+    if !valid {
+        return invalid(format!("{path} must be a valid IPv4 loopback address"));
+    }
+    Ok(listen)
+}
+
+fn rpc_url(value: &Value) -> Result<String, DynError> {
+    let path = "security.chain_rpc_url";
+    let rpc = non_empty_string(value, path)?;
+    let valid = rpc.parse::<http::Uri>().ok().is_some_and(|uri| {
+        matches!(uri.scheme_str(), Some("http" | "https")) && uri.authority().is_some()
+    });
+    if !valid {
+        return invalid(format!("{path} must use http or https"));
+    }
+    Ok(rpc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_cluster_config() -> Value {
+        json!({
+            "apps": {
+                "bns_dv": {
+                    "settings": {
+                        "contract": "0x2222222222222222222222222222222222222222",
+                        "chain_id": 31337,
+                        "db": "/var/lib/bns-backend/bns/bns.sqlite",
+                        "listen": "127.0.0.1:1318",
+                        "start_block": 10,
+                        "confirmations": 2,
+                        "interval_ms": 15000
+                    }
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn maps_cluster_config_to_existing_flags_with_defaults() {
+        let mapped = cluster_serve_flags(
+            &sample_cluster_config(),
+            &json!({"chain_rpc_url": "https://rpc.example.test"}),
+        )
+        .unwrap();
+        assert_eq!(mapped.get("rpc").unwrap(), "https://rpc.example.test");
+        assert_eq!(mapped.get("chain-id").unwrap(), "31337");
+        assert_eq!(
+            mapped.get("db").unwrap(),
+            "/var/lib/bns-backend/bns/bns.sqlite"
+        );
+        assert_eq!(mapped.get("max-block-span").unwrap(), "500");
+    }
+
+    #[test]
+    fn command_line_flags_override_every_cluster_value() {
+        let mut cluster = cluster_serve_flags(
+            &sample_cluster_config(),
+            &json!({"chain_rpc_url": "https://rpc.example.test"}),
+        )
+        .unwrap();
+        let overrides = HashMap::from([
+            ("rpc".to_string(), "http://override:8545".to_string()),
+            (
+                "contract".to_string(),
+                "0x3333333333333333333333333333333333333333".to_string(),
+            ),
+            ("chain-id".to_string(), "1".to_string()),
+            ("db".to_string(), "/tmp/override.sqlite".to_string()),
+            ("listen".to_string(), "0.0.0.0:8080".to_string()),
+            ("start-block".to_string(), "20".to_string()),
+            ("confirmations".to_string(), "3".to_string()),
+            ("interval-ms".to_string(), "30000".to_string()),
+            ("max-block-span".to_string(), "750".to_string()),
+        ]);
+        cluster.extend(overrides.clone());
+        for (key, expected) in overrides {
+            assert_eq!(cluster.get(&key), Some(&expected), "override for --{key}");
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_settings() {
+        let mut cluster = sample_cluster_config();
+        cluster["apps"]["bns_dv"]["settings"]["seed_config"] = json!("forbidden.yaml");
+        let error = cluster_serve_flags(
+            &cluster,
+            &json!({"chain_rpc_url": "https://rpc.example.test"}),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("unknown keys: seed_config"), "{error}");
+    }
+}

--- a/src/components/bns-server/src/lib.rs
+++ b/src/components/bns-server/src/lib.rs
@@ -130,9 +130,12 @@ where
         let contract = self.contract_address.as_deref().ok_or_else(|| {
             BnsClientError::unsupported("BNS server contract_address is not configured")
         })?;
-        let contract = Address::from_str(contract).map_err(|error| {
-            BnsClientError::Serialization(format!("invalid BNS contract_address: {error}"))
-        })?;
+        let contract = match self.chain_client.contract_address() {
+            Some(contract) => contract,
+            None => Address::from_str(contract).map_err(|error| {
+                BnsClientError::Serialization(format!("invalid BNS contract_address: {error}"))
+            })?,
+        };
         let actual_chain_id = self
             .chain_client
             .chain_id()

--- a/src/components/bns-server/src/lib.rs
+++ b/src/components/bns-server/src/lib.rs
@@ -23,7 +23,7 @@ use bns_client::{
     METHOD_QUERY_TX_STATE, METHOD_RESOLVE_DOCUMENT, METHOD_RESOLVE_OWNER, METHOD_SUBMIT_RAW_TX,
     METHOD_SYSTEM_INFO,
 };
-use bns_evm::{Address, EthRpcClient, B256};
+use bns_evm::{Address, BnsChainClient, EthRpcClient, B256};
 use bns_indexer::{
     canonical_bns_name, canonical_doc_type, did_bns_from_name, is_top_level_name,
     name_from_did_bns, now_timestamp, parent_name, AliasKind, AuthorityKey, AuthoritySetState,
@@ -59,7 +59,7 @@ where
     S: BnsRegistryStore,
 {
     store: S,
-    eth_rpc: EthRpcClient,
+    chain_client: Arc<BnsChainClient>,
     contract_address: Option<String>,
     expected_chain_id: Option<u64>,
 }
@@ -71,7 +71,7 @@ where
     pub fn new(store: S, evm_rpc_endpoint: impl Into<String>) -> Self {
         Self {
             store,
-            eth_rpc: EthRpcClient::new(evm_rpc_endpoint),
+            chain_client: Arc::new(BnsChainClient::new(evm_rpc_endpoint)),
             contract_address: None,
             expected_chain_id: None,
         }
@@ -85,7 +85,21 @@ where
     ) -> Self {
         Self {
             store,
-            eth_rpc: EthRpcClient::new(evm_rpc_endpoint),
+            chain_client: Arc::new(BnsChainClient::new(evm_rpc_endpoint)),
+            contract_address: Some(contract_address.into()),
+            expected_chain_id: Some(chain_id),
+        }
+    }
+
+    pub fn new_with_chain_client(
+        store: S,
+        chain_client: Arc<BnsChainClient>,
+        contract_address: impl Into<String>,
+        chain_id: u64,
+    ) -> Self {
+        Self {
+            store,
+            chain_client,
             contract_address: Some(contract_address.into()),
             expected_chain_id: Some(chain_id),
         }
@@ -96,7 +110,11 @@ where
     }
 
     pub fn evm_rpc(&self) -> &EthRpcClient {
-        &self.eth_rpc
+        self.chain_client.rpc()
+    }
+
+    pub fn chain_client(&self) -> &Arc<BnsChainClient> {
+        &self.chain_client
     }
 }
 
@@ -116,7 +134,7 @@ where
             BnsClientError::Serialization(format!("invalid BNS contract_address: {error}"))
         })?;
         let actual_chain_id = self
-            .eth_rpc
+            .chain_client
             .chain_id()
             .await
             .map_err(BnsClientError::from)?;
@@ -236,7 +254,7 @@ where
         })?;
         let canonical_hash = format!("{hash:#x}");
         if let Some(receipt) = self
-            .eth_rpc
+            .chain_client
             .transaction_receipt(hash)
             .await
             .map_err(BnsClientError::from)?
@@ -244,7 +262,7 @@ where
             let block_number = receipt.block_number;
             let confirmations = match block_number {
                 Some(block_number) => self
-                    .eth_rpc
+                    .chain_client
                     .block_number()
                     .await
                     .map_err(BnsClientError::from)?
@@ -265,7 +283,7 @@ where
         }
 
         let state = if self
-            .eth_rpc
+            .chain_client
             .transaction_by_hash(hash)
             .await
             .map_err(BnsClientError::from)?
@@ -286,7 +304,7 @@ where
     async fn submit_raw_tx(&self, req: BnsSubmitRawTxReq) -> BnsClientResult<BnsSubmitRawTxResp> {
         let raw_tx = req.raw_tx_bytes()?;
         let tx_hash = self
-            .eth_rpc
+            .chain_client
             .send_raw_transaction(&raw_tx)
             .await
             .map_err(BnsClientError::from)?;
@@ -305,18 +323,18 @@ where
         })?;
         let calldata = req.calldata_bytes()?;
         let nonce = self
-            .eth_rpc
+            .chain_client
             .transaction_count(from)
             .await
             .map_err(BnsClientError::from)?;
         let estimated_gas = self
-            .eth_rpc
+            .chain_client
             .estimate_gas(from, contract, calldata.as_slice())
             .await
             .map_err(BnsClientError::from)?;
         let gas_buffer = estimated_gas / 5 + u64::from(estimated_gas % 5 != 0);
         let fees = self
-            .eth_rpc
+            .chain_client
             .suggest_eip1559_fees()
             .await
             .map_err(BnsClientError::from)?;
@@ -619,6 +637,23 @@ where
             BnsContractServerHandler::new_with_chain_config(
                 store,
                 evm_rpc_endpoint,
+                contract_address,
+                chain_id,
+            ),
+            BnsIndexerHttpServerConfig::default().with_rpc_path(BNS_SERVER_RPC_PATH),
+        )
+    }
+
+    pub fn from_contract_store_with_chain_client(
+        store: S,
+        chain_client: Arc<BnsChainClient>,
+        contract_address: impl Into<String>,
+        chain_id: u64,
+    ) -> Self {
+        Self::with_config(
+            BnsContractServerHandler::new_with_chain_client(
+                store,
+                chain_client,
                 contract_address,
                 chain_id,
             ),

--- a/src/components/bns-server/src/lib.rs
+++ b/src/components/bns-server/src/lib.rs
@@ -23,7 +23,7 @@ use bns_client::{
     METHOD_QUERY_TX_STATE, METHOD_RESOLVE_DOCUMENT, METHOD_RESOLVE_OWNER, METHOD_SUBMIT_RAW_TX,
     METHOD_SYSTEM_INFO,
 };
-use bns_evm::{Address, BnsChainClient, EthRpcClient, B256};
+use bns_evm::{Address, BnsChainClient, EthRpcClient, TransactionLookup, B256};
 use bns_indexer::{
     canonical_bns_name, canonical_doc_type, did_bns_from_name, is_top_level_name,
     name_from_did_bns, now_timestamp, parent_name, AliasKind, AuthorityKey, AuthoritySetState,
@@ -256,52 +256,54 @@ where
             BnsClientError::Serialization(format!("invalid tx_hash `{tx_hash}`: {error}"))
         })?;
         let canonical_hash = format!("{hash:#x}");
-        if let Some(receipt) = self
+        let lookup = self
             .chain_client
-            .transaction_receipt(hash)
+            .transaction_lookup(hash)
             .await
-            .map_err(BnsClientError::from)?
-        {
-            let block_number = receipt.block_number;
-            let confirmations = match block_number {
-                Some(block_number) => self
-                    .chain_client
-                    .block_number()
-                    .await
-                    .map_err(BnsClientError::from)?
-                    .checked_sub(block_number)
-                    .map_or(0, |depth| depth.saturating_add(1)),
-                None => 0,
-            };
-            return Ok(BnsTxState {
+            .map_err(BnsClientError::from)?;
+        match lookup {
+            TransactionLookup::Mined(receipt) => {
+                let block_number = receipt.block_number;
+                let confirmations = match block_number {
+                    Some(block_number) => {
+                        let latest_block = match self.chain_client.cached_latest_block() {
+                            Some(head) => head.number.unwrap_or(0),
+                            None => self
+                                .chain_client
+                                .block_number()
+                                .await
+                                .map_err(BnsClientError::from)?,
+                        };
+                        latest_block
+                            .checked_sub(block_number)
+                            .map_or(0, |depth| depth.saturating_add(1))
+                    }
+                    None => 0,
+                };
+                Ok(BnsTxState {
+                    tx_hash: canonical_hash,
+                    state: if receipt.status == Some(0) {
+                        BnsTxExecutionState::Reverted
+                    } else {
+                        BnsTxExecutionState::Succeeded
+                    },
+                    block_number,
+                    confirmations,
+                })
+            }
+            TransactionLookup::Pending => Ok(BnsTxState {
                 tx_hash: canonical_hash,
-                state: if receipt.status == Some(0) {
-                    BnsTxExecutionState::Reverted
-                } else {
-                    BnsTxExecutionState::Succeeded
-                },
-                block_number,
-                confirmations,
-            });
+                state: BnsTxExecutionState::Pending,
+                block_number: None,
+                confirmations: 0,
+            }),
+            TransactionLookup::NotFound => Ok(BnsTxState {
+                tx_hash: canonical_hash,
+                state: BnsTxExecutionState::NotFound,
+                block_number: None,
+                confirmations: 0,
+            }),
         }
-
-        let state = if self
-            .chain_client
-            .transaction_by_hash(hash)
-            .await
-            .map_err(BnsClientError::from)?
-            .is_some()
-        {
-            BnsTxExecutionState::Pending
-        } else {
-            BnsTxExecutionState::NotFound
-        };
-        Ok(BnsTxState {
-            tx_hash: canonical_hash,
-            state,
-            block_number: None,
-            confirmations: 0,
-        })
     }
 
     async fn submit_raw_tx(&self, req: BnsSubmitRawTxReq) -> BnsClientResult<BnsSubmitRawTxResp> {

--- a/src/components/bns-server/start_bns_dv.ts
+++ b/src/components/bns-server/start_bns_dv.ts
@@ -10,7 +10,17 @@ const SETTINGS_KEYS = new Set([
   "start_block",
   "confirmations",
   "interval_ms",
+  "max_block_span",
 ]);
+const REQUIRED_SETTINGS_KEYS = [
+  "contract",
+  "chain_id",
+  "db",
+  "listen",
+  "start_block",
+  "confirmations",
+  "interval_ms",
+] as const;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -23,6 +33,7 @@ export interface BnsDvConfig {
   readonly startBlock: number;
   readonly confirmations: number;
   readonly intervalMs: number;
+  readonly maxBlockSpan: number;
 }
 
 function invalid(message: string): never {
@@ -137,7 +148,7 @@ export function parseBnsDvConfig(
       }`,
     );
   }
-  for (const key of SETTINGS_KEYS) {
+  for (const key of REQUIRED_SETTINGS_KEYS) {
     if (!Object.hasOwn(settings, key)) {
       invalid(`apps.${APP_ID}.settings.${key} is missing`);
     }
@@ -165,6 +176,11 @@ export function parseBnsDvConfig(
       `apps.${APP_ID}.settings.interval_ms`,
       1,
     ),
+    maxBlockSpan: integer(
+      settings.max_block_span ?? 500,
+      `apps.${APP_ID}.settings.max_block_span`,
+      1,
+    ),
   });
 }
 
@@ -187,6 +203,8 @@ export function buildBnsDvArgs(config: BnsDvConfig): string[] {
     String(config.confirmations),
     "--interval-ms",
     String(config.intervalMs),
+    "--max-block-span",
+    String(config.maxBlockSpan),
   ];
 }
 


### PR DESCRIPTION
## 背景

`bns_dv` 当前链 API 消耗较大。本 PR 以 SourceDAOBackend 的链访问方式为参考，在不改变 Controller、业务 API、上下游依赖和投影持久化语义的前提下，集中优化与链交互的实现。

完整分析、实施顺序及各项提交 hash 见：

`doc/BNS/bns-dv与SourceDAOBackend链交互对比及优化建议.md`

## 主要改动

1. 抽出共享的 `BnsChainClient`，Indexer 和 Server 通过同一实例访问链。
2. 使用标准 Multicall3 聚合独立的 latest `eth_call`，失败时回退到逐个调用，不新增运行依赖。
3. 缓存已验证的 chain ID、contract 等链级不变量。
4. 后台链操作失败统一等待 30 秒重试；外部 API 链操作失败直接返回错误。
5. 分离 backlog 和 idle 调度：
   - backlog 连续处理；
   - idle 使用 `interval-ms`，默认 15 秒；
   - 新增 `max-block-span`，默认 500。
6. backlog 期间复用同一个 latest head，减少链头和 reorg 校验请求。
7. 仅在 Authority、Controller、Checkpoint 等确实需要 calldata 时读取交易。
8. 对交易状态查询增加 TTL 缓存、并发 singleflight 和 reorg 失效处理。
9. 缓存交易 fee suggestion；nonce 和 gas estimate 仍逐请求读取。
10. 在一个同步分片中对 transaction、name、document、authority、alias 和 checkpoint 补读去重。
11. 对信息完整的 event/calldata 直接投影：
    - Authority key、Controller rule 继续由 calldata 恢复；
    - Checkpoint 由 event 与 calldata 完整恢复，并校验 `externalAnchor`；
    - 无法严格恢复的 name/document/alias 时间字段仍使用 latest 补读。
12. 原生支持 `bns_dv serve --cluster`：
    - 固定读取 `/etc/cluster_config/cluster_config.json`；
    - 固定读取 `/etc/security/security_config.json`；
    - 映射到现有 serve 参数；
    - 显式命令行参数优先；
    - 保留 `start_bns_dv.ts` 作为兼容入口。

## 兼容性边界

- 未修改 Controller 代码。
- 常规 `serve` 和 `serve --cluster` 不创建 Controller。
- 只有本地测试显式传入 `--config`/`--seed-config` 时，才沿用既有初始化交易流程。
- 未改变 kRPC、WebUI、cyfs-sn 或其他上下游业务 API。
- 历史事件补读继续使用 latest；完整追赶后投影收敛到链上最新状态。
- `start_bns_dv.ts` 保留，现有 CD 和测试脚本可以渐进迁移。

## 验证

通过：

- `cargo check -p bns-evm -p bns-indexer`
- `cargo test -p bns-evm -- --test-threads=1`
  - 30 passed
- `cargo test -p bns-indexer -- --test-threads=1`
  - 45 passed
- `cargo test -p bns-client -- --test-threads=1`
  - 39 passed，6 个既有 Anvil E2E 测试 ignored
- Cluster 配置隔离测试
  - 3 passed
- 修改目标的 `rustfmt --check`
- `deno check start_bns_dv.ts`
- `deno fmt --check start_bns_dv.ts`

bns_dv full smoke test passed against a freshly initialized local Anvil chain, covering contract deployment, name registration, document publication, event indexing, and document retrieval through the server/client/controller smoke-test path.